### PR TITLE
Upgrading to groovy 4

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -21,4 +21,4 @@ jobs:
           distribution: zulu
       - uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishPlugin -PpublishPluginChannels=beta -PpublishPluginToken=${{ secrets.JB_PLUGINS_TOKEN }} -PideVersion=IC-2022.3 -PgroovyVersion=3.0.9 -PspockVersion=2.0-groovy-3.0 -PpluginVersion=6.0.0-${{ env.SNAPSHOT_SUFFIX }}
+          arguments: publishPlugin -PpublishPluginChannels=beta -PpublishPluginToken=${{ secrets.JB_PLUGINS_TOKEN }} -PideVersion=IC-2022.3 -PpluginVersion=6.0.0-${{ env.SNAPSHOT_SUFFIX }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false # we need to know which version is failing
       matrix:
         version:
-          - "-PideVersion=IC-2022.3 -PgroovyVersion=3.0.9 -PspockVersion=2.0-groovy-3.0"
+          - "-PideVersion=IC-2022.3"
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,4 @@ jobs:
           distribution: zulu
       - uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishPlugin -PpublishPluginToken=${{ secrets.JB_PLUGINS_TOKEN }} -PideVersion=IC-2022.3 -PgroovyVersion=3.0.13 -PspockVersion=2.1-groovy-3.0 -PpluginVersion=${{ steps.version.outputs.tag }}
+          arguments: publishPlugin -PpublishPluginToken=${{ secrets.JB_PLUGINS_TOKEN }} -PideVersion=IC-2022.3 -PpluginVersion=${{ steps.version.outputs.tag }}

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly( 'org.codehaus.groovy:groovy') {
+    compileOnly( 'org.apache.groovy:groovy') {
         version {
             strictly "$groovyVersion"
         }
@@ -55,29 +55,32 @@ dependencies {
     }
     implementation("org.codenarc:CodeNarc:$codenarcVersion") {
         exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.appache.groovy'
     }
 
     implementation 'io.sentry:sentry:5.1.0'
 
-    runtimeOnly('org.gmetrics:GMetrics:1.1') {
+    runtimeOnly('org.gmetrics:GMetrics-Groovy4:2.1.0') {
         exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.appache.groovy'
     }
 
     compile 'org.apache.commons:commons-lang3:3.9'
 
     testImplementation "org.spockframework:spock-core:$spockVersion", {
         exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.appache.groovy'
     }
 
     testImplementation 'com.agorapulse.testing:fixt:0.2.1.1'
-    testImplementation( 'org.codehaus.groovy:groovy') {
+    testImplementation( 'org.apache.groovy:groovy') {
         version {
             strictly "$groovyVersion"
         }
         because 'there are version conflicts when building'
     }
 
-    generatorImplementation( 'org.codehaus.groovy:groovy') {
+    generatorImplementation( 'org.apache.groovy:groovy') {
         version {
             strictly "$groovyVersion"
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-codenarcVersion=3.1.0
+codenarcVersion=3.2.0-groovy-4.0
 pluginVersion=7.0.0-SNAPSHOT
-groovyVersion=3.0.9
-spockVersion=2.0-groovy-3.0
+groovyVersion=4.0.10
+spockVersion=2.3-groovy-4.0

--- a/src/test/groovy/org/codenarc/idea/testing/FixtureHelper.groovy
+++ b/src/test/groovy/org/codenarc/idea/testing/FixtureHelper.groovy
@@ -20,8 +20,8 @@ import org.junit.Ignore
 @Ignore // not a JUnit test
 class FixtureHelper extends LightJavaCodeInsightFixtureTestCase implements Closeable {
 
-    static FixtureHelper groovy25() {
-        return new FixtureHelper(GroovyProjectDescriptors.GROOVY_2_5, null)
+    static FixtureHelper groovy40() {
+        return new FixtureHelper(GroovyProjectDescriptors.GROOVY_4_0, null)
     }
 
     private final LightProjectDescriptor projectDescriptor;

--- a/src/test/groovy/org/codenarc/idea/testing/GroovyProjectDescriptors.java
+++ b/src/test/groovy/org/codenarc/idea/testing/GroovyProjectDescriptors.java
@@ -15,6 +15,7 @@ public interface GroovyProjectDescriptors {
   TestLibrary LIB_GROOVY_2_4 = new RepositoryTestLibrary("org.codehaus.groovy:groovy-all:2.4.17");
   TestLibrary LIB_GROOVY_2_5 = new RepositoryTestLibrary("org.codehaus.groovy:groovy:2.5.12");
   TestLibrary LIB_GROOVY_3_0 = new RepositoryTestLibrary("org.codehaus.groovy:groovy:3.0.7");
+  TestLibrary LIB_GROOVY_4_0 = new RepositoryTestLibrary("org.apache.groovy:groovy:4.0.10");
 
   LightProjectDescriptor GROOVY_1_6 = new LibraryLightProjectDescriptor(LIB_GROOVY_1_6);
   LightProjectDescriptor GROOVY_1_7 = new LibraryLightProjectDescriptor(LIB_GROOVY_1_7);
@@ -24,10 +25,17 @@ public interface GroovyProjectDescriptors {
   LightProjectDescriptor GROOVY_2_4 = new LibraryLightProjectDescriptor(LIB_GROOVY_2_4);
   LightProjectDescriptor GROOVY_2_5 = new LibraryLightProjectDescriptor(LIB_GROOVY_2_5);
   LightProjectDescriptor GROOVY_3_0 = new LibraryLightProjectDescriptor(LIB_GROOVY_3_0);
+  LightProjectDescriptor GROOVY_4_0 = new LibraryLightProjectDescriptor(LIB_GROOVY_4_0);
 
-  TestLibrary LIB_GROOVY_LATEST = LIB_GROOVY_2_4;
+  TestLibrary LIB_GROOVY_LATEST = LIB_GROOVY_4_0;
   LightProjectDescriptor GROOVY_LATEST = new LibraryLightProjectDescriptor(LIB_GROOVY_LATEST);
   LightProjectDescriptor GROOVY_LATEST_REAL_JDK = new LibraryLightProjectDescriptor(LIB_GROOVY_LATEST) {
+    @Override
+    public Sdk getSdk() {
+      return JavaSdk.getInstance().createJdk("TEST_JDK", IdeaTestUtil.requireRealJdkHome(), false);
+    }
+  };
+  LightProjectDescriptor GROOVY_4_0_REAL_JDK = new LibraryLightProjectDescriptor(LIB_GROOVY_4_0) {
     @Override
     public Sdk getSdk() {
       return JavaSdk.getInstance().createJdk("TEST_JDK", IdeaTestUtil.requireRealJdkHome(), false);

--- a/src/test/groovy/org/codenarc/idea/testing/InspectionSpec.groovy
+++ b/src/test/groovy/org/codenarc/idea/testing/InspectionSpec.groovy
@@ -62,7 +62,7 @@ abstract class InspectionSpec extends Specification {
 
     String fileName =  "${UUID.randomUUID()}.groovy"
 
-    @AutoCleanup FixtureHelper helper = FixtureHelper.groovy25().start { JavaCodeInsightTestFixture fixture ->
+    @AutoCleanup FixtureHelper helper = FixtureHelper.groovy40().start { JavaCodeInsightTestFixture fixture ->
         enableInspections(inspection)
 
         configure(fixture)


### PR DESCRIPTION
Upgrading to Groovy 4:
Rework of https://github.com/melix/codenarc-idea/pull/63

Upgrade notes:
GMetrics:1.1 -> GMetrics-Groovy4:2.1.0
CodeNarc:3.1.0 -> CodeNarc:3.2.0-groovy-4.
org.codehaus.groovy:groovy:3.0.9 -> org.apache.groovy:groovy:4.0.10
spock-core:2.0-groovy-3.0 -> spock-core:2.3-groovy-4.0

Removing build matrix over spock and groovy.