### PR TITLE
Add error-prone, JSpecify, and NullAway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'idea'
     id 'groovy'
     id 'application'
+    id "net.ltgt.errorprone" version "4.3.0"
 }
 
 project.group = 'org.codenarc.idea'
@@ -101,6 +102,11 @@ dependencies {
 
     compile 'org.apache.commons:commons-lang3:3.18.0'
 
+    // Null-enforcement
+    errorprone "com.google.errorprone:error_prone_core:2.45.0"
+    errorprone "com.uber.nullaway:nullaway:0.12.14"
+    api 'org.jspecify:jspecify:1.0.0'
+
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-engine:1.10.0'
@@ -118,6 +124,21 @@ dependencies {
             strictly groovyVersion
         }
         because 'there are version conflicts when building'
+    }
+}
+
+// Null-enforcement
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+        //noinspection UnnecessaryQualifiedReference, GroovyAssignabilityCheck
+        check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+        option("NullAway:AnnotatedPackages", "org.codenarc.idea")
+    }
+
+    if (name.toLowerCase().contains("test")) {
+        options.errorprone {
+            disable("NullAway")
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ideVersion=2025.3
-pluginVersion=7.0.6
+pluginVersion=7.0.7
 codenarcVersion=3.6.0-groovy-4.0
 groovyVersion=4.0.29
 spockVersion=2.3-groovy-4.0

--- a/src/generator/groovy/org/codenarc/idea/gen/RuleInspectionsGenerator.groovy
+++ b/src/generator/groovy/org/codenarc/idea/gen/RuleInspectionsGenerator.groovy
@@ -362,7 +362,7 @@ class RuleInspectionsGenerator {
                 'org.codenarc.idea.CodeNarcInspectionTool',
                 'org.codenarc.rule.Violation',
                 ruleClass,
-                'org.jetbrains.annotations.NotNull',
+                'org.jspecify.annotations.NonNull',
                 'java.util.Collection',
                 'java.util.Collections',
         ])
@@ -433,7 +433,7 @@ class RuleInspectionsGenerator {
 
         String emptyListQuickFixImplementation = '''
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull` Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
         '''

--- a/src/generator/groovy/org/codenarc/idea/gen/RuleInspectionsGenerator.groovy
+++ b/src/generator/groovy/org/codenarc/idea/gen/RuleInspectionsGenerator.groovy
@@ -31,7 +31,7 @@ import org.codenarc.rule.unused.UnusedPrivateFieldRule
 import org.codenarc.rule.unused.UnusedPrivateMethodParameterRule
 import org.codenarc.rule.unused.UnusedPrivateMethodRule
 import org.codenarc.rule.unused.UnusedVariableRule
-import org.jetbrains.annotations.Nullable
+import org.jspecify.annotations.Nullable
 
 import java.util.jar.JarEntry
 import java.util.jar.JarFile

--- a/src/main/java/org/codenarc/idea/CodeNarcBundle.java
+++ b/src/main/java/org/codenarc/idea/CodeNarcBundle.java
@@ -3,13 +3,14 @@ package org.codenarc.idea;
 import com.intellij.DynamicBundle;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.PropertyKey;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;
 
+@NullMarked
 public class CodeNarcBundle extends DynamicBundle {
-
     @NonNls
     private static final String BUNDLE = "messages.CodeNarcBundle";
     private static final CodeNarcBundle INSTANCE = new CodeNarcBundle();
@@ -18,14 +19,14 @@ public class CodeNarcBundle extends DynamicBundle {
         super(BUNDLE);
     }
 
-    @NotNull
-    public static @Nls String message(@NotNull @PropertyKey(resourceBundle = BUNDLE) String key, Object... params) {
+    public static @Nls String message(@PropertyKey(resourceBundle = BUNDLE) String key, @Nullable Object... params) {
         return INSTANCE.getMessage(key, params);
     }
 
-    @NotNull
-    public static Supplier<String> messagePointer(@NotNull @PropertyKey(resourceBundle = BUNDLE) String key, Object... params) {
+    public static Supplier<String> messagePointer(
+        @PropertyKey(resourceBundle = BUNDLE) String key,
+        @Nullable Object... params
+    ) {
         return INSTANCE.getLazyMessage(key, params);
     }
-
 }

--- a/src/main/java/org/codenarc/idea/CodeNarcInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/CodeNarcInspectionTool.java
@@ -43,8 +43,6 @@ import org.codenarc.source.SourceString;
 import org.jdom.Element;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.PropertyKey;
 
 import javax.swing.*;
@@ -57,12 +55,15 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 /**
- * Base class for CodeNarc violation rules, which will get proxied in order to work with the IntelliJ IDEA inspection
+ * Base class for CodeNarc violation rules, which will get proxied to work with the IntelliJ IDEA inspection
  * plugin mechanism.
  */
+@NullMarked
 public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends LocalInspectionTool {
-
     public static final String BASE_MESSAGES_BUNDLE = "codenarc-base-messages";
     public static final String GROUP_DISPLAY_NAME = "CodeNarc";
 
@@ -141,42 +142,36 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
 
     private String getRuleDescriptionOrDefaultMessage(final AbstractRule rule) {
         String resourceKey = rule.getName() + ".description.html";
-        return "[" + rule.getName() + "] " + getResourceBundleString(resourceKey, "No description provided");
+        return "[" + rule.getName() + "] " + getResourceBundleString(resourceKey);
     }
 
-    private String getResourceBundleString(
-        @PropertyKey(resourceBundle = BASE_MESSAGES_BUNDLE) String resourceKey,
-        String defaultString
-    ) {
-        String string;
+    private String getResourceBundleString(@PropertyKey(resourceBundle = BASE_MESSAGES_BUNDLE) String resourceKey) {
         try {
-            string = bundle.getString(resourceKey);
+            return bundle.getString(resourceKey);
         } catch (MissingResourceException ignored) {
-            string = defaultString;
+            return "No description provided";
         }
-
-        return string;
     }
 
     public abstract String getRuleset();
 
     @Override
-    public @NonNls @Nullable String getAlternativeID() {
+    public @NonNls String getAlternativeID() {
         return (rule.getName() != null ? rule.getName() : rule.getClass().getSimpleName());
     }
 
     @Override
-    public JPanel createOptionsPanel() {
+    public @Nullable JPanel createOptionsPanel() {
         return Helpers.createOptionsPanel(this);
     }
 
     @Override
-    public void writeSettings(@NotNull Element node) {
+    public void writeSettings(Element node) {
         XmlSerializer.serializeObjectInto(this.rule, node);
     }
 
     @Override
-    public void readSettings(@NotNull Element node) {
+    public void readSettings(Element node) {
         try {
             if (node.getChild("option") != null) {
                 XmlSerializer.deserializeInto(node, this.rule);
@@ -191,7 +186,7 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
     }
 
     @Override
-    public @Nls(capitalization = Nls.Capitalization.Sentence) @NotNull String getGroupDisplayName() {
+    public @Nls(capitalization = Nls.Capitalization.Sentence) String getGroupDisplayName() {
         return getRuleset();
     }
 
@@ -202,7 +197,7 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
     }
 
     @Override
-    public @Nls(capitalization = Nls.Capitalization.Sentence) String @NotNull [] getGroupPath() {
+    public @Nls(capitalization = Nls.Capitalization.Sentence) String[] getGroupPath() {
         return new String[]{GROUP_DISPLAY_NAME, getRuleset()};
     }
 
@@ -213,9 +208,9 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
 
     @Override
     @SuppressWarnings("unchecked")
-    public ProblemDescriptor[] checkFile(
-        @NotNull final PsiFile file,
-        @NotNull final InspectionManager manager,
+    public ProblemDescriptor @Nullable [] checkFile(
+        final PsiFile file,
+        final InspectionManager manager,
         final boolean isOnTheFly
     ) {
         if (!file.getFileType().getName().equalsIgnoreCase("groovy")) {
@@ -224,7 +219,7 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
 
         final CachedValuesManager cachedValuesManager = CachedValuesManager.getManager(manager.getProject());
 
-        if (readErrorsCachedValue(file, cachedValuesManager).getValue() == Boolean.TRUE) {
+        if (readErrorsCachedValue(file, cachedValuesManager).getValue()) {
             // avoid inspection if any syntax error is found
             return null;
         }
@@ -268,9 +263,10 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
         return cachedViolations.getValue(rule);
     }
 
-    // this method is nearly the same as the on in superclass but it uses altarnative ID (without CodeNarc) prefix
+    // this method is nearly the same as in the superclass, but it uses alternative ID (without CodeNarc) prefix
     // to be aligned with CodeNarc behaviour
-    public SuppressQuickFix @NotNull [] getBatchSuppressActions(@Nullable PsiElement element) {
+    @Override
+    public SuppressQuickFix[] getBatchSuppressActions(@Nullable PsiElement element) {
         if (element == null) {
             return SuppressQuickFix.EMPTY_ARRAY;
         }
@@ -280,14 +276,14 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
                 if (object == null) {
                     return 0;
                 }
-                int result = object instanceof InjectionAwareSuppressQuickFix
-                        ? ((InjectionAwareSuppressQuickFix)object).isShouldBeAppliedToInjectionHost().hashCode()
+                int result = object instanceof InjectionAwareSuppressQuickFix obj
+                        ? obj.isShouldBeAppliedToInjectionHost().hashCode()
                         : 0;
                 return 31 * result + object.getName().hashCode();
             }
 
             @Override
-            public boolean equals(SuppressQuickFix o1, SuppressQuickFix o2) {
+            public boolean equals(@Nullable SuppressQuickFix o1, @Nullable SuppressQuickFix o2) {
                 if (o1 == o2) {
                     return true;
                 }
@@ -295,9 +291,8 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
                     return false;
                 }
 
-                if (o1 instanceof InjectionAwareSuppressQuickFix && o2 instanceof InjectionAwareSuppressQuickFix) {
-                    if (((InjectionAwareSuppressQuickFix)o1).isShouldBeAppliedToInjectionHost() !=
-                            ((InjectionAwareSuppressQuickFix)o2).isShouldBeAppliedToInjectionHost()) {
+                if (o1 instanceof InjectionAwareSuppressQuickFix _o1 && o2 instanceof InjectionAwareSuppressQuickFix _o2) {
+                    if (_o1.isShouldBeAppliedToInjectionHost() != _o2.isShouldBeAppliedToInjectionHost()) {
                         return false;
                     }
                 }
@@ -327,16 +322,12 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
         return fixes.toArray(SuppressQuickFix.EMPTY_ARRAY);
     }
 
-    protected abstract @NotNull Collection<LocalQuickFix> getQuickFixesFor(
-        Violation violation,
-        PsiElement violatingElement
-    );
+    protected abstract Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement);
 
     protected void applyDefaultConfiguration(R rule) {
-        // allows override the defaults in the subclasses
+        // allows overriding the defaults in the subclasses
     }
 
-    @NotNull
     protected TextRange convertViolationRangeToRelative(PsiElement violatingElement, TextRange violatingRange) {
         final int relativeRangeStart = violatingElement.getTextRange().getStartOffset() -
             violatingRange.getStartOffset();
@@ -344,12 +335,10 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
         return new TextRange(Math.max(0, relativeRangeStart), relativeRangeEnd);
     }
 
-    @Nullable
-    protected PsiElement extractViolatingElement(@NotNull PsiFile file, TextRange violatingRange) {
+    protected @Nullable PsiElement extractViolatingElement(PsiFile file, TextRange violatingRange) {
         return PsiUtil.getElementInclusiveRange(file, violatingRange);
     }
 
-    @NotNull
     protected TextRange extractViolatingRange(Document document, Violation violation) {
         final int lineNumber = extractLineNumber(violation);
         final int startOffset = Math.max(document.getLineStartOffset(lineNumber - 1), 0);
@@ -372,17 +361,15 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
         return defaultRange;
     }
 
-    protected String extractMessage(Violation violation, R r) {
-        final String message = violation.getMessage();
-        String currentDescription = description == null ? r.getName() : description;
-        return message == null ? currentDescription : message;
+    protected String extractMessage(Violation violation) {
+        return Objects.requireNonNullElse(violation.getMessage(), description);
     }
 
     protected int extractLineNumber(Violation violation) {
         Integer lineNumber = violation.getLineNumber();
 
         // workaround for some rules which do not set the line number correctly
-        // these should roverride this method
+        // these should override this method
         if (lineNumber == null || lineNumber < 1) {
             return 1;
         }
@@ -390,27 +377,27 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
         return lineNumber;
     }
 
-
-    private static void addAllSuppressActions(@NotNull Collection<? super SuppressQuickFix> fixes,
-                                              @NotNull PsiElement element,
-                                              @NotNull InspectionSuppressor suppressor,
-                                              @NotNull ThreeState appliedToInjectionHost,
-                                              @NotNull String toolId) {
+    private static void addAllSuppressActions(
+        Collection<? super SuppressQuickFix> fixes,
+        PsiElement element,
+        InspectionSuppressor suppressor,
+        ThreeState appliedToInjectionHost,
+        String toolId
+    ) {
         final SuppressQuickFix[] actions = suppressor.getSuppressActions(element, toolId);
         for (SuppressQuickFix action : actions) {
-            if (action instanceof InjectionAwareSuppressQuickFix) {
-                ((InjectionAwareSuppressQuickFix)action).setShouldBeAppliedToInjectionHost(appliedToInjectionHost);
+            if (action instanceof InjectionAwareSuppressQuickFix _action) {
+                _action.setShouldBeAppliedToInjectionHost(appliedToInjectionHost);
             }
             fixes.add(action);
         }
     }
 
-    @Nullable
-    private ProblemDescriptor[] doCheckFile(
-        @NotNull PsiFile file,
-        @NotNull InspectionManager manager,
+    private ProblemDescriptor @Nullable [] doCheckFile(
+        PsiFile file,
+        InspectionManager manager,
         boolean isOnTheFly,
-        SourceCode code,
+        @Nullable SourceCode code,
         R r
     ) throws Throwable {
         if (code == null) {
@@ -440,7 +427,7 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
             return list
                     .stream()
                     .map(violation ->
-                        convertViolationToProblemDescriptor(file, manager, isOnTheFly, r, document, violation)
+                        convertViolationToProblemDescriptor(file, manager, isOnTheFly, document, violation)
                     )
                     .filter(Objects::nonNull)
                     .toArray(ProblemDescriptor[]::new);
@@ -458,12 +445,10 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
 
     }
 
-    @Nullable
-    private ProblemDescriptor convertViolationToProblemDescriptor(
-        @NotNull PsiFile file,
-        @NotNull InspectionManager manager,
+    private @Nullable ProblemDescriptor convertViolationToProblemDescriptor(
+        PsiFile file,
+        InspectionManager manager,
         boolean isOnTheFly,
-        R r,
         Document document,
         Violation violation
     ) {
@@ -471,9 +456,9 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
         final PsiElement violatingElement = extractViolatingElement(file, violatingRange);
 
         if (
-            violatingElement == null || isSuppressedFor(violatingElement) || (
-                DisabledRulesService.getInstance().isRuleDisabled(violation.getRule(), file, violation.getLineNumber())
-            )
+            violatingElement == null ||
+            isSuppressedFor(violatingElement) ||
+            DisabledRulesService.getInstance().isRuleDisabled(violation.getRule(), file, violation.getLineNumber())
         ) {
             return null;
         }
@@ -481,15 +466,14 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
         return manager.createProblemDescriptor(
                 violatingElement,
                 convertViolationRangeToRelative(violatingElement, violatingRange),
-                extractMessage(violation, r),
+                extractMessage(violation),
                 ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
                 isOnTheFly,
                 getQuickFixesFor(violation, violatingElement).toArray(new LocalQuickFix[0])
         );
     }
 
-    @NotNull
-    private CachedValue<Boolean> readErrorsCachedValue(@NotNull PsiFile file, CachedValuesManager cachedValuesManager) {
+    private CachedValue<Boolean> readErrorsCachedValue(PsiFile file, CachedValuesManager cachedValuesManager) {
         CachedValue<Boolean> hasErrorsCachedValue = file.getUserData(HAS_SYNTAX_ERRORS_CACHE_KEY);
         if (hasErrorsCachedValue == null) {
             hasErrorsCachedValue = cachedValuesManager.createCachedValue(() -> {
@@ -501,7 +485,7 @@ public abstract class CodeNarcInspectionTool<R extends AbstractRule> extends Loc
     }
 
     private <T> T computeCachedDataIfAbsent(
-        @NotNull PsiFile file,
+        PsiFile file,
         CachedValuesManager cachedValuesManager,
         Key<CachedValue<T>> key,
         Supplier<T> supplier

--- a/src/main/java/org/codenarc/idea/disablerules/DisabledRulesLookupTable.java
+++ b/src/main/java/org/codenarc/idea/disablerules/DisabledRulesLookupTable.java
@@ -1,12 +1,13 @@
 package org.codenarc.idea.disablerules;
 
 import org.codenarc.rule.Rule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+@NullMarked
 class DisabledRulesLookupTable {
     protected static final String ALL_RULES = "#ALL#";
     private static final String CODENARC_DISABLE = "codenarc-disable";
@@ -21,16 +22,16 @@ class DisabledRulesLookupTable {
 
     private boolean isDisablingAllRules = false;
 
-    DisabledRulesLookupTable(@NotNull String sourceCode) {
+    DisabledRulesLookupTable(String sourceCode) {
         buildLookupTable(sourceCode);
     }
 
-    boolean isRuleDisabledForLine(@NotNull Rule rule, int lineNumber) {
+    boolean isRuleDisabledForLine(Rule rule, int lineNumber) {
         var disabledRules = disabledRulesByLine.get(lineNumber);
         return disabledRules != null && (disabledRules.contains(ALL_RULES) || disabledRules.contains(rule.getName()));
     }
 
-    private void buildLookupTable(@NotNull String sourceCode) {
+    private void buildLookupTable(String sourceCode) {
         var lineNumber = new AtomicInteger(1);
         sourceCode.lines().forEach(line -> {
             checkForCodeNarcDisable(line);

--- a/src/main/java/org/codenarc/idea/disablerules/DisabledRulesService.java
+++ b/src/main/java/org/codenarc/idea/disablerules/DisabledRulesService.java
@@ -2,14 +2,15 @@ package org.codenarc.idea.disablerules;
 
 import com.intellij.psi.PsiFile;
 import org.codenarc.rule.Rule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+@NullMarked
 public class DisabledRulesService {
-    private static DisabledRulesService instance;
-
+    private static @Nullable DisabledRulesService instance;
     private static final Map<String, CachedDisabledRulesLookupTable> cache = new LinkedHashMap<>();
 
     public static DisabledRulesService getInstance() {
@@ -22,7 +23,7 @@ public class DisabledRulesService {
 
     private DisabledRulesService() {}
 
-    public boolean isRuleDisabled(@NotNull Rule rule, @NotNull PsiFile file, Integer lineNumber) {
+    public boolean isRuleDisabled(Rule rule, PsiFile file, @Nullable Integer lineNumber) {
         if (lineNumber == null) {
             lineNumber = 1;
         }
@@ -30,9 +31,11 @@ public class DisabledRulesService {
         return getDisabledRulesLookupTable(file).isRuleDisabledForLine(rule, lineNumber);
     }
 
-    private DisabledRulesLookupTable getDisabledRulesLookupTable(@NotNull PsiFile file) {
+    private DisabledRulesLookupTable getDisabledRulesLookupTable(PsiFile file) {
         var virtualFile = file.getVirtualFile();
-        var cacheKey = virtualFile != null ? virtualFile.getCanonicalPath() : file.getName();
+        var cacheKey = (virtualFile != null && virtualFile.getCanonicalPath() != null)
+            ? virtualFile.getCanonicalPath()
+            : file.getName();
 
         var cacheValue = cache.get(cacheKey);
         if (cacheValue == null || cacheValue.modificationStamp != file.getModificationStamp()) {

--- a/src/main/java/org/codenarc/idea/error/SentryErrorSubmitter.java
+++ b/src/main/java/org/codenarc/idea/error/SentryErrorSubmitter.java
@@ -1,12 +1,11 @@
 package org.codenarc.idea.error;
 
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
-import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.idea.IdeaLogger;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ApplicationNamesInfo;
-import com.intellij.openapi.application.ex.ApplicationInfoEx;
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.text.StringUtil;
@@ -14,69 +13,65 @@ import com.intellij.util.Consumer;
 import groovy.lang.GroovySystem;
 import io.sentry.Sentry;
 import io.sentry.SentryEvent;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.awt.*;
 
+@NullMarked
 public class SentryErrorSubmitter extends ErrorReportSubmitter {
-
-    /*
-     * @return text that is used on the Error Reporter's submit button, e.g. "Report to JetBrains".
+    /**
+     * @return text that is used on the Error Submit button, e.g. "Report to JetBrains".
      */
     @Override
-    public @NotNull String getReportActionText() {
+    public String getReportActionText() {
         return "Report CodeNarc IDEA Issue";
     }
 
-    /*
+    /**
      * @return the text to display in the UI in T&C of privacy policy (under the stack trace)
      */
     @Override
     public String getPrivacyNoticeText() {
-        return "Please provide a brief description to explain how the error occurred. By submitting this bug report you are agreeing for the displayed stacktrace to be shared with the developers via <a href=\"https://sentry.io\">sentry.io</a>. Please also consider raising a bug directly on our <a href=\"https://github.com/melix/codenarc-idea\">Github</a>.";
+        return "Please provide a brief description to explain how the error occurred. By submitting this bug report " +
+            "you are agreeing for the displayed stacktrace to be shared with the developers via " +
+            "<a href=\"https://sentry.io\">sentry.io</a>. Please also consider raising a bug directly on our " +
+            "<a href=\"https://github.com/melix/codenarc-idea\">Github</a>.";
     }
 
     @Override
     public boolean submit(
-            IdeaLoggingEvent @NotNull [] events,
+            IdeaLoggingEvent[] events,
             @Nullable String additionalInfo,
-            @NotNull Component parentComponent,
-            @NotNull Consumer consumer
+            Component parentComponent,
+            Consumer consumer
     ) {
+        if (!Sentry.isEnabled()) {
+            Sentry.init(options -> {
+                options.setDsn("https://fd7d1b52354a4d5e91c09af65c80d9dc@o91700.ingest.sentry.io/5748879");
+                options.setAttachStacktrace(true);
+                options.setAttachServerName(false);
 
-        Sentry.init(options -> {
-            options.setDsn("https://fd7d1b52354a4d5e91c09af65c80d9dc@o91700.ingest.sentry.io/5748879");
-            options.setAttachStacktrace(true);
-            options.setAttachServerName(false);
+                options.setTag("OS Name", SystemInfo.OS_NAME);
+                options.setTag("Java version", SystemInfo.JAVA_VERSION);
+                options.setTag("Java vendor", SystemInfo.JAVA_VENDOR);
+                options.setTag("Groovy version", GroovySystem.getVersion());
+                options.setTag("IDE Name", ApplicationNamesInfo.getInstance().getProductName());
+                options.setTag("IDE Full Name", ApplicationNamesInfo.getInstance().getFullProductNameWithEdition());
+                options.setTag("IDE Version", ApplicationInfo.getInstance().getFullVersion());
+                options.setTag("IDE Build", ApplicationInfo.getInstance().getBuild().asString());
+                options.setTag("Is EAP", String.valueOf(ApplicationInfo.getInstance().isEAP()));
 
-            options.setTag("OS Name", SystemInfo.OS_NAME);
-            options.setTag("Java version", SystemInfo.JAVA_VERSION);
-            options.setTag("Java vendor", SystemInfo.JAVA_VENDOR);
-            options.setTag("Groovy version", GroovySystem.getVersion());
-            options.setTag("IDE Name", ApplicationNamesInfo.getInstance().getProductName());
-            options.setTag("IDE Full Name", ApplicationNamesInfo.getInstance().getFullProductNameWithEdition());
-            options.setTag("IDE Version", ApplicationInfo.getInstance().getFullVersion());
-            options.setTag("IDE Build", ApplicationInfo.getInstance().getBuild().asString());
-            options.setTag("Is EAP", String.valueOf(((ApplicationInfoEx) ApplicationInfo.getInstance()).isEAP()));
-
-            if (super.getPluginDescriptor() != null) {
-                var plugin = PluginManagerCore.getPlugin(super.getPluginDescriptor().getPluginId());
-                if (plugin != null) {
-                    options.setTag("Plugin", plugin.getName());
-                    options.setTag("Version", plugin.getVersion());
+                var pluginDescriptor = PluginManager.getPluginByClass(this.getClass());
+                if (pluginDescriptor != null) {
+                    options.setTag("Plugin", pluginDescriptor.getName());
+                    options.setTag("Version", pluginDescriptor.getVersion());
                 }
-            }
-        });
-
+            });
+        }
 
         for (IdeaLoggingEvent e : events) {
-            Throwable error = null;
-            if (e instanceof IdeaLoggingEvent) {
-                error = e.getThrowable();
-            }
-
-            var sentryEvent = new SentryEvent(error);
+            var sentryEvent = new SentryEvent(e.getThrowable());
 
             if (additionalInfo != null) {
                 sentryEvent.setExtra("User Comments", additionalInfo);
@@ -93,6 +88,4 @@ public class SentryErrorSubmitter extends ErrorReportSubmitter {
 
         return true; // return true to indicate that a process has begun to send data async
     }
-
-
 }

--- a/src/main/java/org/codenarc/idea/inspections/basic/AssertWithinFinallyBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/AssertWithinFinallyBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.AssertWithinFinallyBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class AssertWithinFinallyBlockInspectionTool extends CodeNarcInspectionTool<AssertWithinFinallyBlockRule> {
@@ -48,7 +48,7 @@ public class AssertWithinFinallyBlockInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/AssignmentInConditionalInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/AssignmentInConditionalInspectionTool.java
@@ -9,7 +9,7 @@ import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.idea.quickfix.ReplaceStatementFix;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.AssignmentInConditionalRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrAssignmentExpression;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
@@ -50,7 +50,7 @@ public class AssignmentInConditionalInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.singleton(new ReplaceStatementFix(GrAssignmentExpression.class, "=", "=="));
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/BigDecimalInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/BigDecimalInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.BigDecimalInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BigDecimalInstantiationInspectionTool extends CodeNarcInspectionTool<BigDecimalInstantiationRule> {
@@ -48,7 +48,7 @@ public class BigDecimalInstantiationInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/BitwiseOperatorInConditionalInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/BitwiseOperatorInConditionalInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.BitwiseOperatorInConditionalRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BitwiseOperatorInConditionalInspectionTool extends CodeNarcInspectionTool<BitwiseOperatorInConditionalRule> {
@@ -48,7 +48,7 @@ public class BitwiseOperatorInConditionalInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/BooleanGetBooleanInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/BooleanGetBooleanInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.BooleanGetBooleanRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BooleanGetBooleanInspectionTool extends CodeNarcInspectionTool<BooleanGetBooleanRule> {
@@ -48,7 +48,7 @@ public class BooleanGetBooleanInspectionTool extends CodeNarcInspectionTool<Bool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/BrokenNullCheckInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/BrokenNullCheckInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.BrokenNullCheckRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BrokenNullCheckInspectionTool extends CodeNarcInspectionTool<BrokenNullCheckRule> {
@@ -48,7 +48,7 @@ public class BrokenNullCheckInspectionTool extends CodeNarcInspectionTool<Broken
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/BrokenOddnessCheckInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/BrokenOddnessCheckInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.BrokenOddnessCheckRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BrokenOddnessCheckInspectionTool extends CodeNarcInspectionTool<BrokenOddnessCheckRule> {
@@ -48,7 +48,7 @@ public class BrokenOddnessCheckInspectionTool extends CodeNarcInspectionTool<Bro
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ClassForNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ClassForNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ClassForNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClassForNameInspectionTool extends CodeNarcInspectionTool<ClassForNameRule> {
@@ -48,7 +48,7 @@ public class ClassForNameInspectionTool extends CodeNarcInspectionTool<ClassForN
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ComparisonOfTwoConstantsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ComparisonOfTwoConstantsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ComparisonOfTwoConstantsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ComparisonOfTwoConstantsInspectionTool extends CodeNarcInspectionTool<ComparisonOfTwoConstantsRule> {
@@ -48,7 +48,7 @@ public class ComparisonOfTwoConstantsInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ComparisonWithSelfInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ComparisonWithSelfInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ComparisonWithSelfRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ComparisonWithSelfInspectionTool extends CodeNarcInspectionTool<ComparisonWithSelfRule> {
@@ -48,7 +48,7 @@ public class ComparisonWithSelfInspectionTool extends CodeNarcInspectionTool<Com
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ConstantAssertExpressionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ConstantAssertExpressionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ConstantAssertExpressionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConstantAssertExpressionInspectionTool extends CodeNarcInspectionTool<ConstantAssertExpressionRule> {
@@ -48,7 +48,7 @@ public class ConstantAssertExpressionInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ConstantIfExpressionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ConstantIfExpressionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ConstantIfExpressionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConstantIfExpressionInspectionTool extends CodeNarcInspectionTool<ConstantIfExpressionRule> {
@@ -48,7 +48,7 @@ public class ConstantIfExpressionInspectionTool extends CodeNarcInspectionTool<C
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ConstantTernaryExpressionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ConstantTernaryExpressionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ConstantTernaryExpressionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConstantTernaryExpressionInspectionTool extends CodeNarcInspectionTool<ConstantTernaryExpressionRule> {
@@ -48,7 +48,7 @@ public class ConstantTernaryExpressionInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/DeadCodeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/DeadCodeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.DeadCodeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DeadCodeInspectionTool extends CodeNarcInspectionTool<DeadCodeRule> {
@@ -48,7 +48,7 @@ public class DeadCodeInspectionTool extends CodeNarcInspectionTool<DeadCodeRule>
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/DoubleNegativeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/DoubleNegativeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.DoubleNegativeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DoubleNegativeInspectionTool extends CodeNarcInspectionTool<DoubleNegativeRule> {
@@ -48,7 +48,7 @@ public class DoubleNegativeInspectionTool extends CodeNarcInspectionTool<DoubleN
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/DuplicateCaseStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/DuplicateCaseStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.DuplicateCaseStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DuplicateCaseStatementInspectionTool extends CodeNarcInspectionTool<DuplicateCaseStatementRule> {
@@ -48,7 +48,7 @@ public class DuplicateCaseStatementInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/DuplicateMapKeyInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/DuplicateMapKeyInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.DuplicateMapKeyRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DuplicateMapKeyInspectionTool extends CodeNarcInspectionTool<DuplicateMapKeyRule> {
@@ -48,7 +48,7 @@ public class DuplicateMapKeyInspectionTool extends CodeNarcInspectionTool<Duplic
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/DuplicateSetValueInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/DuplicateSetValueInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.DuplicateSetValueRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DuplicateSetValueInspectionTool extends CodeNarcInspectionTool<DuplicateSetValueRule> {
@@ -48,7 +48,7 @@ public class DuplicateSetValueInspectionTool extends CodeNarcInspectionTool<Dupl
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyCatchBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyCatchBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyCatchBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyCatchBlockInspectionTool extends CodeNarcInspectionTool<EmptyCatchBlockRule> {
@@ -57,7 +57,7 @@ public class EmptyCatchBlockInspectionTool extends CodeNarcInspectionTool<EmptyC
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyClassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyClassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyClassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyClassInspectionTool extends CodeNarcInspectionTool<EmptyClassRule> {
@@ -48,7 +48,7 @@ public class EmptyClassInspectionTool extends CodeNarcInspectionTool<EmptyClassR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyElseBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyElseBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyElseBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyElseBlockInspectionTool extends CodeNarcInspectionTool<EmptyElseBlockRule> {
@@ -48,7 +48,7 @@ public class EmptyElseBlockInspectionTool extends CodeNarcInspectionTool<EmptyEl
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyFinallyBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyFinallyBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyFinallyBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyFinallyBlockInspectionTool extends CodeNarcInspectionTool<EmptyFinallyBlockRule> {
@@ -48,7 +48,7 @@ public class EmptyFinallyBlockInspectionTool extends CodeNarcInspectionTool<Empt
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyForStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyForStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyForStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyForStatementInspectionTool extends CodeNarcInspectionTool<EmptyForStatementRule> {
@@ -48,7 +48,7 @@ public class EmptyForStatementInspectionTool extends CodeNarcInspectionTool<Empt
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyIfStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyIfStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyIfStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyIfStatementInspectionTool extends CodeNarcInspectionTool<EmptyIfStatementRule> {
@@ -48,7 +48,7 @@ public class EmptyIfStatementInspectionTool extends CodeNarcInspectionTool<Empty
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyInstanceInitializerInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyInstanceInitializerInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyInstanceInitializerRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyInstanceInitializerInspectionTool extends CodeNarcInspectionTool<EmptyInstanceInitializerRule> {
@@ -48,7 +48,7 @@ public class EmptyInstanceInitializerInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyMethodInspectionTool extends CodeNarcInspectionTool<EmptyMethodRule> {
@@ -48,7 +48,7 @@ public class EmptyMethodInspectionTool extends CodeNarcInspectionTool<EmptyMetho
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyStaticInitializerInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyStaticInitializerInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyStaticInitializerRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyStaticInitializerInspectionTool extends CodeNarcInspectionTool<EmptyStaticInitializerRule> {
@@ -48,7 +48,7 @@ public class EmptyStaticInitializerInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptySwitchStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptySwitchStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptySwitchStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptySwitchStatementInspectionTool extends CodeNarcInspectionTool<EmptySwitchStatementRule> {
@@ -48,7 +48,7 @@ public class EmptySwitchStatementInspectionTool extends CodeNarcInspectionTool<E
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptySynchronizedStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptySynchronizedStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptySynchronizedStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptySynchronizedStatementInspectionTool extends CodeNarcInspectionTool<EmptySynchronizedStatementRule> {
@@ -48,7 +48,7 @@ public class EmptySynchronizedStatementInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyTryBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyTryBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyTryBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyTryBlockInspectionTool extends CodeNarcInspectionTool<EmptyTryBlockRule> {
@@ -48,7 +48,7 @@ public class EmptyTryBlockInspectionTool extends CodeNarcInspectionTool<EmptyTry
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EmptyWhileStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EmptyWhileStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EmptyWhileStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyWhileStatementInspectionTool extends CodeNarcInspectionTool<EmptyWhileStatementRule> {
@@ -48,7 +48,7 @@ public class EmptyWhileStatementInspectionTool extends CodeNarcInspectionTool<Em
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EqualsAndHashCodeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EqualsAndHashCodeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EqualsAndHashCodeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EqualsAndHashCodeInspectionTool extends CodeNarcInspectionTool<EqualsAndHashCodeRule> {
@@ -48,7 +48,7 @@ public class EqualsAndHashCodeInspectionTool extends CodeNarcInspectionTool<Equa
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/EqualsOverloadedInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/EqualsOverloadedInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.EqualsOverloadedRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EqualsOverloadedInspectionTool extends CodeNarcInspectionTool<EqualsOverloadedRule> {
@@ -48,7 +48,7 @@ public class EqualsOverloadedInspectionTool extends CodeNarcInspectionTool<Equal
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ExplicitGarbageCollectionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ExplicitGarbageCollectionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ExplicitGarbageCollectionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitGarbageCollectionInspectionTool extends CodeNarcInspectionTool<ExplicitGarbageCollectionRule> {
@@ -48,7 +48,7 @@ public class ExplicitGarbageCollectionInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ForLoopShouldBeWhileLoopInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ForLoopShouldBeWhileLoopInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ForLoopShouldBeWhileLoopRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ForLoopShouldBeWhileLoopInspectionTool extends CodeNarcInspectionTool<ForLoopShouldBeWhileLoopRule> {
@@ -48,7 +48,7 @@ public class ForLoopShouldBeWhileLoopInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/HardCodedWindowsFileSeparatorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/HardCodedWindowsFileSeparatorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.HardCodedWindowsFileSeparatorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class HardCodedWindowsFileSeparatorInspectionTool extends CodeNarcInspectionTool<HardCodedWindowsFileSeparatorRule> {
@@ -48,7 +48,7 @@ public class HardCodedWindowsFileSeparatorInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/HardCodedWindowsRootDirectoryInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/HardCodedWindowsRootDirectoryInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.HardCodedWindowsRootDirectoryRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class HardCodedWindowsRootDirectoryInspectionTool extends CodeNarcInspectionTool<HardCodedWindowsRootDirectoryRule> {
@@ -48,7 +48,7 @@ public class HardCodedWindowsRootDirectoryInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/IntegerGetIntegerInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/IntegerGetIntegerInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.IntegerGetIntegerRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IntegerGetIntegerInspectionTool extends CodeNarcInspectionTool<IntegerGetIntegerRule> {
@@ -48,7 +48,7 @@ public class IntegerGetIntegerInspectionTool extends CodeNarcInspectionTool<Inte
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/MultipleUnaryOperatorsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/MultipleUnaryOperatorsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.MultipleUnaryOperatorsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MultipleUnaryOperatorsInspectionTool extends CodeNarcInspectionTool<MultipleUnaryOperatorsRule> {
@@ -48,7 +48,7 @@ public class MultipleUnaryOperatorsInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ParameterAssignmentInFilterClosureInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ParameterAssignmentInFilterClosureInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ParameterAssignmentInFilterClosureRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ParameterAssignmentInFilterClosureInspectionTool extends CodeNarcInspectionTool<ParameterAssignmentInFilterClosureRule> {
@@ -48,7 +48,7 @@ public class ParameterAssignmentInFilterClosureInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/RandomDoubleCoercedToZeroInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/RandomDoubleCoercedToZeroInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.RandomDoubleCoercedToZeroRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class RandomDoubleCoercedToZeroInspectionTool extends CodeNarcInspectionTool<RandomDoubleCoercedToZeroRule> {
@@ -48,7 +48,7 @@ public class RandomDoubleCoercedToZeroInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/RemoveAllOnSelfInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/RemoveAllOnSelfInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.RemoveAllOnSelfRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class RemoveAllOnSelfInspectionTool extends CodeNarcInspectionTool<RemoveAllOnSelfRule> {
@@ -48,7 +48,7 @@ public class RemoveAllOnSelfInspectionTool extends CodeNarcInspectionTool<Remove
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ReturnFromFinallyBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ReturnFromFinallyBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ReturnFromFinallyBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ReturnFromFinallyBlockInspectionTool extends CodeNarcInspectionTool<ReturnFromFinallyBlockRule> {
@@ -48,7 +48,7 @@ public class ReturnFromFinallyBlockInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/basic/ThrowExceptionFromFinallyBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/basic/ThrowExceptionFromFinallyBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.basic.ThrowExceptionFromFinallyBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThrowExceptionFromFinallyBlockInspectionTool extends CodeNarcInspectionTool<ThrowExceptionFromFinallyBlockRule> {
@@ -48,7 +48,7 @@ public class ThrowExceptionFromFinallyBlockInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/braces/ElseBlockBracesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/braces/ElseBlockBracesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.braces.ElseBlockBracesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ElseBlockBracesInspectionTool extends CodeNarcInspectionTool<ElseBlockBracesRule> {
@@ -57,7 +57,7 @@ public class ElseBlockBracesInspectionTool extends CodeNarcInspectionTool<ElseBl
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/braces/ForStatementBracesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/braces/ForStatementBracesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.braces.ForStatementBracesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ForStatementBracesInspectionTool extends CodeNarcInspectionTool<ForStatementBracesRule> {
@@ -48,7 +48,7 @@ public class ForStatementBracesInspectionTool extends CodeNarcInspectionTool<For
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/braces/IfStatementBracesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/braces/IfStatementBracesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.braces.IfStatementBracesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IfStatementBracesInspectionTool extends CodeNarcInspectionTool<IfStatementBracesRule> {
@@ -48,7 +48,7 @@ public class IfStatementBracesInspectionTool extends CodeNarcInspectionTool<IfSt
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/braces/WhileStatementBracesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/braces/WhileStatementBracesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.braces.WhileStatementBracesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class WhileStatementBracesInspectionTool extends CodeNarcInspectionTool<WhileStatementBracesRule> {
@@ -48,7 +48,7 @@ public class WhileStatementBracesInspectionTool extends CodeNarcInspectionTool<W
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/ClassJavadocInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/ClassJavadocInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.ClassJavadocRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClassJavadocInspectionTool extends CodeNarcInspectionTool<ClassJavadocRule> {
@@ -39,7 +39,7 @@ public class ClassJavadocInspectionTool extends CodeNarcInspectionTool<ClassJava
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocConsecutiveEmptyLinesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocConsecutiveEmptyLinesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocConsecutiveEmptyLinesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocConsecutiveEmptyLinesInspectionTool extends CodeNarcInspectionTool<JavadocConsecutiveEmptyLinesRule> {
@@ -48,7 +48,7 @@ public class JavadocConsecutiveEmptyLinesInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyAuthorTagInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyAuthorTagInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptyAuthorTagRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptyAuthorTagInspectionTool extends CodeNarcInspectionTool<JavadocEmptyAuthorTagRule> {
@@ -57,7 +57,7 @@ public class JavadocEmptyAuthorTagInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyExceptionTagInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyExceptionTagInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptyExceptionTagRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptyExceptionTagInspectionTool extends CodeNarcInspectionTool<JavadocEmptyExceptionTagRule> {
@@ -57,7 +57,7 @@ public class JavadocEmptyExceptionTagInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyFirstLineInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyFirstLineInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptyFirstLineRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptyFirstLineInspectionTool extends CodeNarcInspectionTool<JavadocEmptyFirstLineRule> {
@@ -30,7 +30,7 @@ public class JavadocEmptyFirstLineInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyLastLineInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyLastLineInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptyLastLineRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptyLastLineInspectionTool extends CodeNarcInspectionTool<JavadocEmptyLastLineRule> {
@@ -48,7 +48,7 @@ public class JavadocEmptyLastLineInspectionTool extends CodeNarcInspectionTool<J
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyParamTagInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyParamTagInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptyParamTagRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptyParamTagInspectionTool extends CodeNarcInspectionTool<JavadocEmptyParamTagRule> {
@@ -57,7 +57,7 @@ public class JavadocEmptyParamTagInspectionTool extends CodeNarcInspectionTool<J
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyReturnTagInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyReturnTagInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptyReturnTagRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptyReturnTagInspectionTool extends CodeNarcInspectionTool<JavadocEmptyReturnTagRule> {
@@ -57,7 +57,7 @@ public class JavadocEmptyReturnTagInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptySeeTagInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptySeeTagInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptySeeTagRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptySeeTagInspectionTool extends CodeNarcInspectionTool<JavadocEmptySeeTagRule> {
@@ -57,7 +57,7 @@ public class JavadocEmptySeeTagInspectionTool extends CodeNarcInspectionTool<Jav
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptySinceTagInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptySinceTagInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptySinceTagRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptySinceTagInspectionTool extends CodeNarcInspectionTool<JavadocEmptySinceTagRule> {
@@ -57,7 +57,7 @@ public class JavadocEmptySinceTagInspectionTool extends CodeNarcInspectionTool<J
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyThrowsTagInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyThrowsTagInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptyThrowsTagRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptyThrowsTagInspectionTool extends CodeNarcInspectionTool<JavadocEmptyThrowsTagRule> {
@@ -57,7 +57,7 @@ public class JavadocEmptyThrowsTagInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyVersionTagInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocEmptyVersionTagInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocEmptyVersionTagRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocEmptyVersionTagInspectionTool extends CodeNarcInspectionTool<JavadocEmptyVersionTagRule> {
@@ -57,7 +57,7 @@ public class JavadocEmptyVersionTagInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocMissingExceptionDescriptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocMissingExceptionDescriptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocMissingExceptionDescriptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocMissingExceptionDescriptionInspectionTool extends CodeNarcInspectionTool<JavadocMissingExceptionDescriptionRule> {
@@ -57,7 +57,7 @@ public class JavadocMissingExceptionDescriptionInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocMissingParamDescriptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocMissingParamDescriptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocMissingParamDescriptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocMissingParamDescriptionInspectionTool extends CodeNarcInspectionTool<JavadocMissingParamDescriptionRule> {
@@ -57,7 +57,7 @@ public class JavadocMissingParamDescriptionInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/JavadocMissingThrowsDescriptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/JavadocMissingThrowsDescriptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.JavadocMissingThrowsDescriptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavadocMissingThrowsDescriptionInspectionTool extends CodeNarcInspectionTool<JavadocMissingThrowsDescriptionRule> {
@@ -57,7 +57,7 @@ public class JavadocMissingThrowsDescriptionInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/SpaceAfterCommentDelimiterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/SpaceAfterCommentDelimiterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.SpaceAfterCommentDelimiterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterCommentDelimiterInspectionTool extends CodeNarcInspectionTool<SpaceAfterCommentDelimiterRule> {
@@ -30,7 +30,7 @@ public class SpaceAfterCommentDelimiterInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/comments/SpaceBeforeCommentDelimiterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/comments/SpaceBeforeCommentDelimiterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.comments.SpaceBeforeCommentDelimiterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceBeforeCommentDelimiterInspectionTool extends CodeNarcInspectionTool<SpaceBeforeCommentDelimiterRule> {
@@ -30,7 +30,7 @@ public class SpaceBeforeCommentDelimiterInspectionTool extends CodeNarcInspectio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/BusyWaitInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/BusyWaitInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.BusyWaitRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BusyWaitInspectionTool extends CodeNarcInspectionTool<BusyWaitRule> {
@@ -48,7 +48,7 @@ public class BusyWaitInspectionTool extends CodeNarcInspectionTool<BusyWaitRule>
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/DoubleCheckedLockingInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/DoubleCheckedLockingInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.DoubleCheckedLockingRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DoubleCheckedLockingInspectionTool extends CodeNarcInspectionTool<DoubleCheckedLockingRule> {
@@ -48,7 +48,7 @@ public class DoubleCheckedLockingInspectionTool extends CodeNarcInspectionTool<D
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/InconsistentPropertyLockingInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/InconsistentPropertyLockingInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.InconsistentPropertyLockingRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class InconsistentPropertyLockingInspectionTool extends CodeNarcInspectionTool<InconsistentPropertyLockingRule> {
@@ -48,7 +48,7 @@ public class InconsistentPropertyLockingInspectionTool extends CodeNarcInspectio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/InconsistentPropertySynchronizationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/InconsistentPropertySynchronizationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.InconsistentPropertySynchronizationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class InconsistentPropertySynchronizationInspectionTool extends CodeNarcInspectionTool<InconsistentPropertySynchronizationRule> {
@@ -48,7 +48,7 @@ public class InconsistentPropertySynchronizationInspectionTool extends CodeNarcI
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/NestedSynchronizationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/NestedSynchronizationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.NestedSynchronizationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NestedSynchronizationInspectionTool extends CodeNarcInspectionTool<NestedSynchronizationRule> {
@@ -48,7 +48,7 @@ public class NestedSynchronizationInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/NoScriptBindingsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/NoScriptBindingsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.NoScriptBindingsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NoScriptBindingsInspectionTool extends CodeNarcInspectionTool<NoScriptBindingsRule> {
@@ -48,7 +48,7 @@ public class NoScriptBindingsInspectionTool extends CodeNarcInspectionTool<NoScr
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/StaticCalendarFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/StaticCalendarFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.StaticCalendarFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StaticCalendarFieldInspectionTool extends CodeNarcInspectionTool<StaticCalendarFieldRule> {
@@ -48,7 +48,7 @@ public class StaticCalendarFieldInspectionTool extends CodeNarcInspectionTool<St
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/StaticConnectionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/StaticConnectionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.StaticConnectionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StaticConnectionInspectionTool extends CodeNarcInspectionTool<StaticConnectionRule> {
@@ -48,7 +48,7 @@ public class StaticConnectionInspectionTool extends CodeNarcInspectionTool<Stati
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/StaticDateFormatFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/StaticDateFormatFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.StaticDateFormatFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StaticDateFormatFieldInspectionTool extends CodeNarcInspectionTool<StaticDateFormatFieldRule> {
@@ -48,7 +48,7 @@ public class StaticDateFormatFieldInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/StaticMatcherFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/StaticMatcherFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.StaticMatcherFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StaticMatcherFieldInspectionTool extends CodeNarcInspectionTool<StaticMatcherFieldRule> {
@@ -48,7 +48,7 @@ public class StaticMatcherFieldInspectionTool extends CodeNarcInspectionTool<Sta
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/StaticSimpleDateFormatFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/StaticSimpleDateFormatFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.StaticSimpleDateFormatFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StaticSimpleDateFormatFieldInspectionTool extends CodeNarcInspectionTool<StaticSimpleDateFormatFieldRule> {
@@ -48,7 +48,7 @@ public class StaticSimpleDateFormatFieldInspectionTool extends CodeNarcInspectio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.SynchronizedMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SynchronizedMethodInspectionTool extends CodeNarcInspectionTool<SynchronizedMethodRule> {
@@ -48,7 +48,7 @@ public class SynchronizedMethodInspectionTool extends CodeNarcInspectionTool<Syn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnBoxedPrimitiveInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnBoxedPrimitiveInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.SynchronizedOnBoxedPrimitiveRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SynchronizedOnBoxedPrimitiveInspectionTool extends CodeNarcInspectionTool<SynchronizedOnBoxedPrimitiveRule> {
@@ -48,7 +48,7 @@ public class SynchronizedOnBoxedPrimitiveInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnGetClassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnGetClassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.SynchronizedOnGetClassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SynchronizedOnGetClassInspectionTool extends CodeNarcInspectionTool<SynchronizedOnGetClassRule> {
@@ -48,7 +48,7 @@ public class SynchronizedOnGetClassInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnReentrantLockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnReentrantLockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.SynchronizedOnReentrantLockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SynchronizedOnReentrantLockInspectionTool extends CodeNarcInspectionTool<SynchronizedOnReentrantLockRule> {
@@ -48,7 +48,7 @@ public class SynchronizedOnReentrantLockInspectionTool extends CodeNarcInspectio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnStringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.SynchronizedOnStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SynchronizedOnStringInspectionTool extends CodeNarcInspectionTool<SynchronizedOnStringRule> {
@@ -48,7 +48,7 @@ public class SynchronizedOnStringInspectionTool extends CodeNarcInspectionTool<S
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnThisInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedOnThisInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.SynchronizedOnThisRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SynchronizedOnThisInspectionTool extends CodeNarcInspectionTool<SynchronizedOnThisRule> {
@@ -48,7 +48,7 @@ public class SynchronizedOnThisInspectionTool extends CodeNarcInspectionTool<Syn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedReadObjectMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/SynchronizedReadObjectMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.SynchronizedReadObjectMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SynchronizedReadObjectMethodInspectionTool extends CodeNarcInspectionTool<SynchronizedReadObjectMethodRule> {
@@ -48,7 +48,7 @@ public class SynchronizedReadObjectMethodInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/SystemRunFinalizersOnExitInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/SystemRunFinalizersOnExitInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.SystemRunFinalizersOnExitRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SystemRunFinalizersOnExitInspectionTool extends CodeNarcInspectionTool<SystemRunFinalizersOnExitRule> {
@@ -48,7 +48,7 @@ public class SystemRunFinalizersOnExitInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/ThisReferenceEscapesConstructorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/ThisReferenceEscapesConstructorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.ThisReferenceEscapesConstructorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThisReferenceEscapesConstructorInspectionTool extends CodeNarcInspectionTool<ThisReferenceEscapesConstructorRule> {
@@ -48,7 +48,7 @@ public class ThisReferenceEscapesConstructorInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/ThreadGroupInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/ThreadGroupInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.ThreadGroupRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThreadGroupInspectionTool extends CodeNarcInspectionTool<ThreadGroupRule> {
@@ -48,7 +48,7 @@ public class ThreadGroupInspectionTool extends CodeNarcInspectionTool<ThreadGrou
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/ThreadLocalNotStaticFinalInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/ThreadLocalNotStaticFinalInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.ThreadLocalNotStaticFinalRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThreadLocalNotStaticFinalInspectionTool extends CodeNarcInspectionTool<ThreadLocalNotStaticFinalRule> {
@@ -48,7 +48,7 @@ public class ThreadLocalNotStaticFinalInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/ThreadYieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/ThreadYieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.ThreadYieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThreadYieldInspectionTool extends CodeNarcInspectionTool<ThreadYieldRule> {
@@ -48,7 +48,7 @@ public class ThreadYieldInspectionTool extends CodeNarcInspectionTool<ThreadYiel
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/UseOfNotifyMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/UseOfNotifyMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.UseOfNotifyMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseOfNotifyMethodInspectionTool extends CodeNarcInspectionTool<UseOfNotifyMethodRule> {
@@ -48,7 +48,7 @@ public class UseOfNotifyMethodInspectionTool extends CodeNarcInspectionTool<UseO
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/VolatileArrayFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/VolatileArrayFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.VolatileArrayFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class VolatileArrayFieldInspectionTool extends CodeNarcInspectionTool<VolatileArrayFieldRule> {
@@ -48,7 +48,7 @@ public class VolatileArrayFieldInspectionTool extends CodeNarcInspectionTool<Vol
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/VolatileLongOrDoubleFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/VolatileLongOrDoubleFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.VolatileLongOrDoubleFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class VolatileLongOrDoubleFieldInspectionTool extends CodeNarcInspectionTool<VolatileLongOrDoubleFieldRule> {
@@ -48,7 +48,7 @@ public class VolatileLongOrDoubleFieldInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/concurrency/WaitOutsideOfWhileLoopInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/concurrency/WaitOutsideOfWhileLoopInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.concurrency.WaitOutsideOfWhileLoopRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class WaitOutsideOfWhileLoopInspectionTool extends CodeNarcInspectionTool<WaitOutsideOfWhileLoopRule> {
@@ -48,7 +48,7 @@ public class WaitOutsideOfWhileLoopInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/CompileStaticInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/CompileStaticInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.CompileStaticRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CompileStaticInspectionTool extends CodeNarcInspectionTool<CompileStaticRule> {
@@ -48,7 +48,7 @@ public class CompileStaticInspectionTool extends CodeNarcInspectionTool<CompileS
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/ConfusingTernaryInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/ConfusingTernaryInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.ConfusingTernaryRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConfusingTernaryInspectionTool extends CodeNarcInspectionTool<ConfusingTernaryRule> {
@@ -48,7 +48,7 @@ public class ConfusingTernaryInspectionTool extends CodeNarcInspectionTool<Confu
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/CouldBeElvisInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/CouldBeElvisInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.CouldBeElvisRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CouldBeElvisInspectionTool extends CodeNarcInspectionTool<CouldBeElvisRule> {
@@ -48,7 +48,7 @@ public class CouldBeElvisInspectionTool extends CodeNarcInspectionTool<CouldBeEl
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/CouldBeSwitchStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/CouldBeSwitchStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.CouldBeSwitchStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CouldBeSwitchStatementInspectionTool extends CodeNarcInspectionTool<CouldBeSwitchStatementRule> {
@@ -57,7 +57,7 @@ public class CouldBeSwitchStatementInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/FieldTypeRequiredInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/FieldTypeRequiredInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.FieldTypeRequiredRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class FieldTypeRequiredInspectionTool extends CodeNarcInspectionTool<FieldTypeRequiredRule> {
@@ -57,7 +57,7 @@ public class FieldTypeRequiredInspectionTool extends CodeNarcInspectionTool<Fiel
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/HashtableIsObsoleteInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/HashtableIsObsoleteInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.HashtableIsObsoleteRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class HashtableIsObsoleteInspectionTool extends CodeNarcInspectionTool<HashtableIsObsoleteRule> {
@@ -48,7 +48,7 @@ public class HashtableIsObsoleteInspectionTool extends CodeNarcInspectionTool<Ha
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/IfStatementCouldBeTernaryInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/IfStatementCouldBeTernaryInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.IfStatementCouldBeTernaryRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IfStatementCouldBeTernaryInspectionTool extends CodeNarcInspectionTool<IfStatementCouldBeTernaryRule> {
@@ -57,7 +57,7 @@ public class IfStatementCouldBeTernaryInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/ImplicitClosureParameterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/ImplicitClosureParameterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.ImplicitClosureParameterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ImplicitClosureParameterInspectionTool extends CodeNarcInspectionTool<ImplicitClosureParameterRule> {
@@ -57,7 +57,7 @@ public class ImplicitClosureParameterInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/ImplicitReturnStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/ImplicitReturnStatementInspectionTool.java
@@ -10,7 +10,7 @@ import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.idea.quickfix.AddExplicitReturnQuickFix;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.ImplicitReturnStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ImplicitReturnStatementInspectionTool extends CodeNarcInspectionTool<ImplicitReturnStatementRule> implements CleanupLocalInspectionTool {
@@ -50,7 +50,7 @@ public class ImplicitReturnStatementInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.singleton(new AddExplicitReturnQuickFix());
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/InvertedConditionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/InvertedConditionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.InvertedConditionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class InvertedConditionInspectionTool extends CodeNarcInspectionTool<InvertedConditionRule> {
@@ -48,7 +48,7 @@ public class InvertedConditionInspectionTool extends CodeNarcInspectionTool<Inve
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/InvertedIfElseInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/InvertedIfElseInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.InvertedIfElseRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class InvertedIfElseInspectionTool extends CodeNarcInspectionTool<InvertedIfElseRule> {
@@ -48,7 +48,7 @@ public class InvertedIfElseInspectionTool extends CodeNarcInspectionTool<Inverte
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/LongLiteralWithLowerCaseLInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/LongLiteralWithLowerCaseLInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.LongLiteralWithLowerCaseLRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class LongLiteralWithLowerCaseLInspectionTool extends CodeNarcInspectionTool<LongLiteralWithLowerCaseLRule> {
@@ -48,7 +48,7 @@ public class LongLiteralWithLowerCaseLInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/MethodParameterTypeRequInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/MethodParameterTypeRequInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.MethodParameterTypeRequired;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MethodParameterTypeRequInspectionTool extends CodeNarcInspectionTool<MethodParameterTypeRequired> {
@@ -57,7 +57,7 @@ public class MethodParameterTypeRequInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/MethodReturnTypeRequiredInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/MethodReturnTypeRequiredInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.MethodReturnTypeRequiredRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MethodReturnTypeRequiredInspectionTool extends CodeNarcInspectionTool<MethodReturnTypeRequiredRule> {
@@ -57,7 +57,7 @@ public class MethodReturnTypeRequiredInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/NoDefInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/NoDefInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.NoDefRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NoDefInspectionTool extends CodeNarcInspectionTool<NoDefRule> {
@@ -48,7 +48,7 @@ public class NoDefInspectionTool extends CodeNarcInspectionTool<NoDefRule> {
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/NoDoubleInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/NoDoubleInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.NoDoubleRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NoDoubleInspectionTool extends CodeNarcInspectionTool<NoDoubleRule> {
@@ -48,7 +48,7 @@ public class NoDoubleInspectionTool extends CodeNarcInspectionTool<NoDoubleRule>
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/NoFloatInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/NoFloatInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.NoFloatRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NoFloatInspectionTool extends CodeNarcInspectionTool<NoFloatRule> {
@@ -48,7 +48,7 @@ public class NoFloatInspectionTool extends CodeNarcInspectionTool<NoFloatRule> {
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/NoJavaUtilDateInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/NoJavaUtilDateInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.NoJavaUtilDateRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NoJavaUtilDateInspectionTool extends CodeNarcInspectionTool<NoJavaUtilDateRule> {
@@ -48,7 +48,7 @@ public class NoJavaUtilDateInspectionTool extends CodeNarcInspectionTool<NoJavaU
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/NoTabCharacterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/NoTabCharacterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.NoTabCharacterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NoTabCharacterInspectionTool extends CodeNarcInspectionTool<NoTabCharacterRule> {
@@ -39,7 +39,7 @@ public class NoTabCharacterInspectionTool extends CodeNarcInspectionTool<NoTabCh
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/ParameterReassignmentInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/ParameterReassignmentInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.ParameterReassignmentRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ParameterReassignmentInspectionTool extends CodeNarcInspectionTool<ParameterReassignmentRule> {
@@ -48,7 +48,7 @@ public class ParameterReassignmentInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/PublicMethodsBeforeNonPublicMethodsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/PublicMethodsBeforeNonPublicMethodsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.PublicMethodsBeforeNonPublicMethodsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PublicMethodsBeforeNonPublicMethodsInspectionTool extends CodeNarcInspectionTool<PublicMethodsBeforeNonPublicMethodsRule> {
@@ -57,7 +57,7 @@ public class PublicMethodsBeforeNonPublicMethodsInspectionTool extends CodeNarcI
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/StaticFieldsBeforeInstanceFieldsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/StaticFieldsBeforeInstanceFieldsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.StaticFieldsBeforeInstanceFieldsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StaticFieldsBeforeInstanceFieldsInspectionTool extends CodeNarcInspectionTool<StaticFieldsBeforeInstanceFieldsRule> {
@@ -48,7 +48,7 @@ public class StaticFieldsBeforeInstanceFieldsInspectionTool extends CodeNarcInsp
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/StaticMethodsBeforeInstanceMethodsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/StaticMethodsBeforeInstanceMethodsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.StaticMethodsBeforeInstanceMethodsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StaticMethodsBeforeInstanceMethodsInspectionTool extends CodeNarcInspectionTool<StaticMethodsBeforeInstanceMethodsRule> {
@@ -57,7 +57,7 @@ public class StaticMethodsBeforeInstanceMethodsInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/TernaryCouldBeElvisInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/TernaryCouldBeElvisInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.TernaryCouldBeElvisRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class TernaryCouldBeElvisInspectionTool extends CodeNarcInspectionTool<TernaryCouldBeElvisRule> {
@@ -48,7 +48,7 @@ public class TernaryCouldBeElvisInspectionTool extends CodeNarcInspectionTool<Te
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/TrailingCommaInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/TrailingCommaInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.TrailingCommaRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class TrailingCommaInspectionTool extends CodeNarcInspectionTool<TrailingCommaRule> {
@@ -84,7 +84,7 @@ public class TrailingCommaInspectionTool extends CodeNarcInspectionTool<Trailing
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/VariableTypeRequiredInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/VariableTypeRequiredInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.VariableTypeRequiredRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class VariableTypeRequiredInspectionTool extends CodeNarcInspectionTool<VariableTypeRequiredRule> {
@@ -57,7 +57,7 @@ public class VariableTypeRequiredInspectionTool extends CodeNarcInspectionTool<V
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/convention/VectorIsObsoleteInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/convention/VectorIsObsoleteInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.convention.VectorIsObsoleteRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class VectorIsObsoleteInspectionTool extends CodeNarcInspectionTool<VectorIsObsoleteRule> {
@@ -48,7 +48,7 @@ public class VectorIsObsoleteInspectionTool extends CodeNarcInspectionTool<Vecto
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/AbstractClassWithPublicConstructorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/AbstractClassWithPublicConstructorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.AbstractClassWithPublicConstructorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class AbstractClassWithPublicConstructorInspectionTool extends CodeNarcInspectionTool<AbstractClassWithPublicConstructorRule> {
@@ -48,7 +48,7 @@ public class AbstractClassWithPublicConstructorInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/AbstractClassWithoutAbstractMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/AbstractClassWithoutAbstractMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.AbstractClassWithoutAbstractMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class AbstractClassWithoutAbstractMethodInspectionTool extends CodeNarcInspectionTool<AbstractClassWithoutAbstractMethodRule> {
@@ -57,7 +57,7 @@ public class AbstractClassWithoutAbstractMethodInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/AssignmentToStaticFieldFromInstanceMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/AssignmentToStaticFieldFromInstanceMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.AssignmentToStaticFieldFromInstanceMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class AssignmentToStaticFieldFromInstanceMethodInspectionTool extends CodeNarcInspectionTool<AssignmentToStaticFieldFromInstanceMethodRule> {
@@ -48,7 +48,7 @@ public class AssignmentToStaticFieldFromInstanceMethodInspectionTool extends Cod
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/BooleanMethodReturnsNullInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/BooleanMethodReturnsNullInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.BooleanMethodReturnsNullRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BooleanMethodReturnsNullInspectionTool extends CodeNarcInspectionTool<BooleanMethodReturnsNullRule> {
@@ -48,7 +48,7 @@ public class BooleanMethodReturnsNullInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/BuilderMethodWithSideEffectsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/BuilderMethodWithSideEffectsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.BuilderMethodWithSideEffectsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BuilderMethodWithSideEffectsInspectionTool extends CodeNarcInspectionTool<BuilderMethodWithSideEffectsRule> {
@@ -57,7 +57,7 @@ public class BuilderMethodWithSideEffectsInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/CloneableWithoutCloneInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/CloneableWithoutCloneInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.CloneableWithoutCloneRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CloneableWithoutCloneInspectionTool extends CodeNarcInspectionTool<CloneableWithoutCloneRule> {
@@ -48,7 +48,7 @@ public class CloneableWithoutCloneInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/CloseWithoutCloseableInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/CloseWithoutCloseableInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.CloseWithoutCloseableRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CloseWithoutCloseableInspectionTool extends CodeNarcInspectionTool<CloseWithoutCloseableRule> {
@@ -57,7 +57,7 @@ public class CloseWithoutCloseableInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/CompareToWithoutComparableInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/CompareToWithoutComparableInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.CompareToWithoutComparableRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CompareToWithoutComparableInspectionTool extends CodeNarcInspectionTool<CompareToWithoutComparableRule> {
@@ -57,7 +57,7 @@ public class CompareToWithoutComparableInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/ConstantsOnlyInterfaceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/ConstantsOnlyInterfaceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.ConstantsOnlyInterfaceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConstantsOnlyInterfaceInspectionTool extends CodeNarcInspectionTool<ConstantsOnlyInterfaceRule> {
@@ -48,7 +48,7 @@ public class ConstantsOnlyInterfaceInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/EmptyMethodInAbstractClassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/EmptyMethodInAbstractClassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.EmptyMethodInAbstractClassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EmptyMethodInAbstractClassInspectionTool extends CodeNarcInspectionTool<EmptyMethodInAbstractClassRule> {
@@ -48,7 +48,7 @@ public class EmptyMethodInAbstractClassInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/FinalClassWithProtectedMemberInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/FinalClassWithProtectedMemberInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.FinalClassWithProtectedMemberRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class FinalClassWithProtectedMemberInspectionTool extends CodeNarcInspectionTool<FinalClassWithProtectedMemberRule> {
@@ -48,7 +48,7 @@ public class FinalClassWithProtectedMemberInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/ImplementationAsTypeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/ImplementationAsTypeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.ImplementationAsTypeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ImplementationAsTypeInspectionTool extends CodeNarcInspectionTool<ImplementationAsTypeRule> {
@@ -48,7 +48,7 @@ public class ImplementationAsTypeInspectionTool extends CodeNarcInspectionTool<I
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/InstanceofInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/InstanceofInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.InstanceofRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class InstanceofInspectionTool extends CodeNarcInspectionTool<InstanceofRule> {
@@ -57,7 +57,7 @@ public class InstanceofInspectionTool extends CodeNarcInspectionTool<InstanceofR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/LocaleSetDefaultInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/LocaleSetDefaultInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.LocaleSetDefaultRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class LocaleSetDefaultInspectionTool extends CodeNarcInspectionTool<LocaleSetDefaultRule> {
@@ -48,7 +48,7 @@ public class LocaleSetDefaultInspectionTool extends CodeNarcInspectionTool<Local
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/NestedForLoopInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/NestedForLoopInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.NestedForLoopRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NestedForLoopInspectionTool extends CodeNarcInspectionTool<NestedForLoopRule> {
@@ -48,7 +48,7 @@ public class NestedForLoopInspectionTool extends CodeNarcInspectionTool<NestedFo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/OptionalCollectionReturnTypeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/OptionalCollectionReturnTypeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.OptionalCollectionReturnTypeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class OptionalCollectionReturnTypeInspectionTool extends CodeNarcInspectionTool<OptionalCollectionReturnTypeRule> {
@@ -48,7 +48,7 @@ public class OptionalCollectionReturnTypeInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/OptionalFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/OptionalFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.OptionalFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class OptionalFieldInspectionTool extends CodeNarcInspectionTool<OptionalFieldRule> {
@@ -48,7 +48,7 @@ public class OptionalFieldInspectionTool extends CodeNarcInspectionTool<Optional
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/OptionalMethodParameterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/OptionalMethodParameterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.OptionalMethodParameterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class OptionalMethodParameterInspectionTool extends CodeNarcInspectionTool<OptionalMethodParameterRule> {
@@ -48,7 +48,7 @@ public class OptionalMethodParameterInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/PrivateFieldCouldBeFinalInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/PrivateFieldCouldBeFinalInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.PrivateFieldCouldBeFinalRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PrivateFieldCouldBeFinalInspectionTool extends CodeNarcInspectionTool<PrivateFieldCouldBeFinalRule> {
@@ -66,7 +66,7 @@ public class PrivateFieldCouldBeFinalInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/PublicInstanceFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/PublicInstanceFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.PublicInstanceFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PublicInstanceFieldInspectionTool extends CodeNarcInspectionTool<PublicInstanceFieldRule> {
@@ -48,7 +48,7 @@ public class PublicInstanceFieldInspectionTool extends CodeNarcInspectionTool<Pu
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/ReturnsNullInsteadOfEmptyArrayInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/ReturnsNullInsteadOfEmptyArrayInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.ReturnsNullInsteadOfEmptyArrayRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ReturnsNullInsteadOfEmptyArrayInspectionTool extends CodeNarcInspectionTool<ReturnsNullInsteadOfEmptyArrayRule> {
@@ -48,7 +48,7 @@ public class ReturnsNullInsteadOfEmptyArrayInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/ReturnsNullInsteadOfEmptyCollectionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/ReturnsNullInsteadOfEmptyCollectionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.ReturnsNullInsteadOfEmptyCollectionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ReturnsNullInsteadOfEmptyCollectionInspectionTool extends CodeNarcInspectionTool<ReturnsNullInsteadOfEmptyCollectionRule> {
@@ -48,7 +48,7 @@ public class ReturnsNullInsteadOfEmptyCollectionInspectionTool extends CodeNarcI
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/SimpleDateFormatMissingLocaleInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/SimpleDateFormatMissingLocaleInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.SimpleDateFormatMissingLocaleRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SimpleDateFormatMissingLocaleInspectionTool extends CodeNarcInspectionTool<SimpleDateFormatMissingLocaleRule> {
@@ -48,7 +48,7 @@ public class SimpleDateFormatMissingLocaleInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/StatelessSingletonInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/StatelessSingletonInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.StatelessSingletonRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StatelessSingletonInspectionTool extends CodeNarcInspectionTool<StatelessSingletonRule> {
@@ -57,7 +57,7 @@ public class StatelessSingletonInspectionTool extends CodeNarcInspectionTool<Sta
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/design/ToStringReturnsNullInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/design/ToStringReturnsNullInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.design.ToStringReturnsNullRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ToStringReturnsNullInspectionTool extends CodeNarcInspectionTool<ToStringReturnsNullRule> {
@@ -48,7 +48,7 @@ public class ToStringReturnsNullInspectionTool extends CodeNarcInspectionTool<To
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/dry/DuplicateListLiteralInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/dry/DuplicateListLiteralInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.dry.DuplicateListLiteralRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DuplicateListLiteralInspectionTool extends CodeNarcInspectionTool<DuplicateListLiteralRule> {
@@ -48,7 +48,7 @@ public class DuplicateListLiteralInspectionTool extends CodeNarcInspectionTool<D
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/dry/DuplicateMapLiteralInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/dry/DuplicateMapLiteralInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.dry.DuplicateMapLiteralRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DuplicateMapLiteralInspectionTool extends CodeNarcInspectionTool<DuplicateMapLiteralRule> {
@@ -48,7 +48,7 @@ public class DuplicateMapLiteralInspectionTool extends CodeNarcInspectionTool<Du
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/dry/DuplicateNumberLiteralInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/dry/DuplicateNumberLiteralInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.dry.DuplicateNumberLiteralRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DuplicateNumberLiteralInspectionTool extends CodeNarcInspectionTool<DuplicateNumberLiteralRule> {
@@ -66,7 +66,7 @@ public class DuplicateNumberLiteralInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/dry/DuplicateStringLiteralInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/dry/DuplicateStringLiteralInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.dry.DuplicateStringLiteralRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DuplicateStringLiteralInspectionTool extends CodeNarcInspectionTool<DuplicateStringLiteralRule> {
@@ -75,7 +75,7 @@ public class DuplicateStringLiteralInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/CatchArrayIndexOutOfBoundsExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/CatchArrayIndexOutOfBoundsExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.CatchArrayIndexOutOfBoundsExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CatchArrayIndexOutOfBoundsExceptionInspectionTool extends CodeNarcInspectionTool<CatchArrayIndexOutOfBoundsExceptionRule> {
@@ -48,7 +48,7 @@ public class CatchArrayIndexOutOfBoundsExceptionInspectionTool extends CodeNarcI
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/CatchErrorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/CatchErrorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.CatchErrorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CatchErrorInspectionTool extends CodeNarcInspectionTool<CatchErrorRule> {
@@ -48,7 +48,7 @@ public class CatchErrorInspectionTool extends CodeNarcInspectionTool<CatchErrorR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/CatchExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/CatchExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.CatchExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CatchExceptionInspectionTool extends CodeNarcInspectionTool<CatchExceptionRule> {
@@ -48,7 +48,7 @@ public class CatchExceptionInspectionTool extends CodeNarcInspectionTool<CatchEx
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/CatchIllegalMonitorStateExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/CatchIllegalMonitorStateExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.CatchIllegalMonitorStateExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CatchIllegalMonitorStateExceptionInspectionTool extends CodeNarcInspectionTool<CatchIllegalMonitorStateExceptionRule> {
@@ -48,7 +48,7 @@ public class CatchIllegalMonitorStateExceptionInspectionTool extends CodeNarcIns
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/CatchIndexOutOfBoundsExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/CatchIndexOutOfBoundsExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.CatchIndexOutOfBoundsExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CatchIndexOutOfBoundsExceptionInspectionTool extends CodeNarcInspectionTool<CatchIndexOutOfBoundsExceptionRule> {
@@ -48,7 +48,7 @@ public class CatchIndexOutOfBoundsExceptionInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/CatchNullPointerExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/CatchNullPointerExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.CatchNullPointerExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CatchNullPointerExceptionInspectionTool extends CodeNarcInspectionTool<CatchNullPointerExceptionRule> {
@@ -48,7 +48,7 @@ public class CatchNullPointerExceptionInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/CatchRuntimeExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/CatchRuntimeExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.CatchRuntimeExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CatchRuntimeExceptionInspectionTool extends CodeNarcInspectionTool<CatchRuntimeExceptionRule> {
@@ -48,7 +48,7 @@ public class CatchRuntimeExceptionInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/CatchThrowableInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/CatchThrowableInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.CatchThrowableRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CatchThrowableInspectionTool extends CodeNarcInspectionTool<CatchThrowableRule> {
@@ -48,7 +48,7 @@ public class CatchThrowableInspectionTool extends CodeNarcInspectionTool<CatchTh
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ConfusingClassNamedExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ConfusingClassNamedExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ConfusingClassNamedExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConfusingClassNamedExceptionInspectionTool extends CodeNarcInspectionTool<ConfusingClassNamedExceptionRule> {
@@ -48,7 +48,7 @@ public class ConfusingClassNamedExceptionInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ExceptionExtendsErrorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ExceptionExtendsErrorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ExceptionExtendsErrorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExceptionExtendsErrorInspectionTool extends CodeNarcInspectionTool<ExceptionExtendsErrorRule> {
@@ -48,7 +48,7 @@ public class ExceptionExtendsErrorInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ExceptionExtendsThrowableInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ExceptionExtendsThrowableInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ExceptionExtendsThrowableRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExceptionExtendsThrowableInspectionTool extends CodeNarcInspectionTool<ExceptionExtendsThrowableRule> {
@@ -48,7 +48,7 @@ public class ExceptionExtendsThrowableInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ExceptionNotThrownInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ExceptionNotThrownInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ExceptionNotThrownRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExceptionNotThrownInspectionTool extends CodeNarcInspectionTool<ExceptionNotThrownRule> {
@@ -48,7 +48,7 @@ public class ExceptionNotThrownInspectionTool extends CodeNarcInspectionTool<Exc
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/MissingNewInThrowStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/MissingNewInThrowStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.MissingNewInThrowStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MissingNewInThrowStatementInspectionTool extends CodeNarcInspectionTool<MissingNewInThrowStatementRule> {
@@ -48,7 +48,7 @@ public class MissingNewInThrowStatementInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ReturnNullFromCatchBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ReturnNullFromCatchBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ReturnNullFromCatchBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ReturnNullFromCatchBlockInspectionTool extends CodeNarcInspectionTool<ReturnNullFromCatchBlockRule> {
@@ -48,7 +48,7 @@ public class ReturnNullFromCatchBlockInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/SwallowThreadDeathInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/SwallowThreadDeathInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.SwallowThreadDeathRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SwallowThreadDeathInspectionTool extends CodeNarcInspectionTool<SwallowThreadDeathRule> {
@@ -48,7 +48,7 @@ public class SwallowThreadDeathInspectionTool extends CodeNarcInspectionTool<Swa
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowErrorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowErrorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ThrowErrorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThrowErrorInspectionTool extends CodeNarcInspectionTool<ThrowErrorRule> {
@@ -48,7 +48,7 @@ public class ThrowErrorInspectionTool extends CodeNarcInspectionTool<ThrowErrorR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ThrowExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThrowExceptionInspectionTool extends CodeNarcInspectionTool<ThrowExceptionRule> {
@@ -48,7 +48,7 @@ public class ThrowExceptionInspectionTool extends CodeNarcInspectionTool<ThrowEx
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowNullPointerExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowNullPointerExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ThrowNullPointerExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThrowNullPointerExceptionInspectionTool extends CodeNarcInspectionTool<ThrowNullPointerExceptionRule> {
@@ -48,7 +48,7 @@ public class ThrowNullPointerExceptionInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowRuntimeExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowRuntimeExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ThrowRuntimeExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThrowRuntimeExceptionInspectionTool extends CodeNarcInspectionTool<ThrowRuntimeExceptionRule> {
@@ -48,7 +48,7 @@ public class ThrowRuntimeExceptionInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowThrowableInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/exceptions/ThrowThrowableInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.exceptions.ThrowThrowableRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ThrowThrowableInspectionTool extends CodeNarcInspectionTool<ThrowThrowableRule> {
@@ -48,7 +48,7 @@ public class ThrowThrowableInspectionTool extends CodeNarcInspectionTool<ThrowTh
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/BlankLineBeforePackageInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/BlankLineBeforePackageInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.BlankLineBeforePackageRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BlankLineBeforePackageInspectionTool extends CodeNarcInspectionTool<BlankLineBeforePackageRule> {
@@ -30,7 +30,7 @@ public class BlankLineBeforePackageInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/BlockEndsWithBlankLineInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/BlockEndsWithBlankLineInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.BlockEndsWithBlankLineRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BlockEndsWithBlankLineInspectionTool extends CodeNarcInspectionTool<BlockEndsWithBlankLineRule> {
@@ -48,7 +48,7 @@ public class BlockEndsWithBlankLineInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/BlockStartsWithBlankLineInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/BlockStartsWithBlankLineInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.BlockStartsWithBlankLineRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BlockStartsWithBlankLineInspectionTool extends CodeNarcInspectionTool<BlockStartsWithBlankLineRule> {
@@ -48,7 +48,7 @@ public class BlockStartsWithBlankLineInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/BracesForClassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/BracesForClassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.BracesForClassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BracesForClassInspectionTool extends CodeNarcInspectionTool<BracesForClassRule> {
@@ -39,7 +39,7 @@ public class BracesForClassInspectionTool extends CodeNarcInspectionTool<BracesF
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/BracesForForLoopInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/BracesForForLoopInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.BracesForForLoopRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BracesForForLoopInspectionTool extends CodeNarcInspectionTool<BracesForForLoopRule> {
@@ -57,7 +57,7 @@ public class BracesForForLoopInspectionTool extends CodeNarcInspectionTool<Brace
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/BracesForIfElseInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/BracesForIfElseInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.BracesForIfElseRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BracesForIfElseInspectionTool extends CodeNarcInspectionTool<BracesForIfElseRule> {
@@ -84,7 +84,7 @@ public class BracesForIfElseInspectionTool extends CodeNarcInspectionTool<Braces
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/BracesForMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/BracesForMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.BracesForMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BracesForMethodInspectionTool extends CodeNarcInspectionTool<BracesForMethodRule> {
@@ -66,7 +66,7 @@ public class BracesForMethodInspectionTool extends CodeNarcInspectionTool<Braces
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/BracesForTryCatchFinallyInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/BracesForTryCatchFinallyInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.BracesForTryCatchFinallyRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class BracesForTryCatchFinallyInspectionTool extends CodeNarcInspectionTool<BracesForTryCatchFinallyRule> {
@@ -111,7 +111,7 @@ public class BracesForTryCatchFinallyInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/ClassEndsWithBlankLineInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/ClassEndsWithBlankLineInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.ClassEndsWithBlankLineRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClassEndsWithBlankLineInspectionTool extends CodeNarcInspectionTool<ClassEndsWithBlankLineRule> {
@@ -75,7 +75,7 @@ public class ClassEndsWithBlankLineInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/ClassStartsWithBlankLineInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/ClassStartsWithBlankLineInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.ClassStartsWithBlankLineRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClassStartsWithBlankLineInspectionTool extends CodeNarcInspectionTool<ClassStartsWithBlankLineRule> {
@@ -75,7 +75,7 @@ public class ClassStartsWithBlankLineInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/ClosureStatementOnOpeningLineOfMultipleLineClosureInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/ClosureStatementOnOpeningLineOfMultipleLineClosureInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.ClosureStatementOnOpeningLineOfMultipleLineClosureRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClosureStatementOnOpeningLineOfMultipleLineClosureInspectionTool extends CodeNarcInspectionTool<ClosureStatementOnOpeningLineOfMultipleLineClosureRule> {
@@ -48,7 +48,7 @@ public class ClosureStatementOnOpeningLineOfMultipleLineClosureInspectionTool ex
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/ConsecutiveBlankLinesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/ConsecutiveBlankLinesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.ConsecutiveBlankLinesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConsecutiveBlankLinesInspectionTool extends CodeNarcInspectionTool<ConsecutiveBlankLinesRule> {
@@ -30,7 +30,7 @@ public class ConsecutiveBlankLinesInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/FileEndsWithoutNewlineInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/FileEndsWithoutNewlineInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.FileEndsWithoutNewlineRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class FileEndsWithoutNewlineInspectionTool extends CodeNarcInspectionTool<FileEndsWithoutNewlineRule> {
@@ -30,7 +30,7 @@ public class FileEndsWithoutNewlineInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/IndentationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/IndentationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.IndentationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IndentationInspectionTool extends CodeNarcInspectionTool<IndentationRule> {
@@ -66,7 +66,7 @@ public class IndentationInspectionTool extends CodeNarcInspectionTool<Indentatio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/LineLengthInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/LineLengthInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.LineLengthRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class LineLengthInspectionTool extends CodeNarcInspectionTool<LineLengthRule> {
@@ -84,7 +84,7 @@ public class LineLengthInspectionTool extends CodeNarcInspectionTool<LineLengthR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/MissingBlankLineAfterImportsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/MissingBlankLineAfterImportsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.MissingBlankLineAfterImportsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MissingBlankLineAfterImportsInspectionTool extends CodeNarcInspectionTool<MissingBlankLineAfterImportsRule> {
@@ -30,7 +30,7 @@ public class MissingBlankLineAfterImportsInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/MissingBlankLineAfterPackageInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/MissingBlankLineAfterPackageInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.MissingBlankLineAfterPackageRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MissingBlankLineAfterPackageInspectionTool extends CodeNarcInspectionTool<MissingBlankLineAfterPackageRule> {
@@ -30,7 +30,7 @@ public class MissingBlankLineAfterPackageInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/MissingBlankLineBeforeAnnotatedFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/MissingBlankLineBeforeAnnotatedFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.MissingBlankLineBeforeAnnotatedFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MissingBlankLineBeforeAnnotatedFieldInspectionTool extends CodeNarcInspectionTool<MissingBlankLineBeforeAnnotatedFieldRule> {
@@ -48,7 +48,7 @@ public class MissingBlankLineBeforeAnnotatedFieldInspectionTool extends CodeNarc
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterCatchInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterCatchInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterCatchRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterCatchInspectionTool extends CodeNarcInspectionTool<SpaceAfterCatchRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterCatchInspectionTool extends CodeNarcInspectionTool<SpaceA
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterClosingBraceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterClosingBraceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterClosingBraceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterClosingBraceInspectionTool extends CodeNarcInspectionTool<SpaceAfterClosingBraceRule> {
@@ -57,7 +57,7 @@ public class SpaceAfterClosingBraceInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterCommaInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterCommaInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterCommaRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterCommaInspectionTool extends CodeNarcInspectionTool<SpaceAfterCommaRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterCommaInspectionTool extends CodeNarcInspectionTool<SpaceA
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterForInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterForInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterForRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterForInspectionTool extends CodeNarcInspectionTool<SpaceAfterForRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterForInspectionTool extends CodeNarcInspectionTool<SpaceAft
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterIfInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterIfInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterIfRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterIfInspectionTool extends CodeNarcInspectionTool<SpaceAfterIfRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterIfInspectionTool extends CodeNarcInspectionTool<SpaceAfte
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterMethodCallNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterMethodCallNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterMethodCallNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterMethodCallNameInspectionTool extends CodeNarcInspectionTool<SpaceAfterMethodCallNameRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterMethodCallNameInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterMethodDeclarationNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterMethodDeclarationNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterMethodDeclarationNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterMethodDeclarationNameInspectionTool extends CodeNarcInspectionTool<SpaceAfterMethodDeclarationNameRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterMethodDeclarationNameInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterNotOperatorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterNotOperatorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterNotOperatorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterNotOperatorInspectionTool extends CodeNarcInspectionTool<SpaceAfterNotOperatorRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterNotOperatorInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterOpeningBraceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterOpeningBraceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterOpeningBraceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterOpeningBraceInspectionTool extends CodeNarcInspectionTool<SpaceAfterOpeningBraceRule> {
@@ -66,7 +66,7 @@ public class SpaceAfterOpeningBraceInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterSemicolonInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterSemicolonInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterSemicolonRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterSemicolonInspectionTool extends CodeNarcInspectionTool<SpaceAfterSemicolonRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterSemicolonInspectionTool extends CodeNarcInspectionTool<Sp
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterSwitchInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterSwitchInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterSwitchRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterSwitchInspectionTool extends CodeNarcInspectionTool<SpaceAfterSwitchRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterSwitchInspectionTool extends CodeNarcInspectionTool<Space
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterWhileInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAfterWhileInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAfterWhileRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAfterWhileInspectionTool extends CodeNarcInspectionTool<SpaceAfterWhileRule> {
@@ -48,7 +48,7 @@ public class SpaceAfterWhileInspectionTool extends CodeNarcInspectionTool<SpaceA
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAroundClosureArrowInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAroundClosureArrowInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAroundClosureArrowRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAroundClosureArrowInspectionTool extends CodeNarcInspectionTool<SpaceAroundClosureArrowRule> {
@@ -48,7 +48,7 @@ public class SpaceAroundClosureArrowInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAroundMapEntryColonInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAroundMapEntryColonInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAroundMapEntryColonRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAroundMapEntryColonInspectionTool extends CodeNarcInspectionTool<SpaceAroundMapEntryColonRule> {
@@ -66,7 +66,7 @@ public class SpaceAroundMapEntryColonInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAroundOperatorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceAroundOperatorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceAroundOperatorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceAroundOperatorInspectionTool extends CodeNarcInspectionTool<SpaceAroundOperatorRule> {
@@ -57,7 +57,7 @@ public class SpaceAroundOperatorInspectionTool extends CodeNarcInspectionTool<Sp
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceBeforeClosingBraceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceBeforeClosingBraceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceBeforeClosingBraceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceBeforeClosingBraceInspectionTool extends CodeNarcInspectionTool<SpaceBeforeClosingBraceRule> {
@@ -66,7 +66,7 @@ public class SpaceBeforeClosingBraceInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceBeforeOpeningBraceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceBeforeOpeningBraceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceBeforeOpeningBraceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceBeforeOpeningBraceInspectionTool extends CodeNarcInspectionTool<SpaceBeforeOpeningBraceRule> {
@@ -57,7 +57,7 @@ public class SpaceBeforeOpeningBraceInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/SpaceInsideParenthesesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/SpaceInsideParenthesesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.SpaceInsideParenthesesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpaceInsideParenthesesInspectionTool extends CodeNarcInspectionTool<SpaceInsideParenthesesRule> {
@@ -48,7 +48,7 @@ public class SpaceInsideParenthesesInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/formatting/TrailingWhitespaceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/formatting/TrailingWhitespaceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.formatting.TrailingWhitespaceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class TrailingWhitespaceInspectionTool extends CodeNarcInspectionTool<TrailingWhitespaceRule> {
@@ -30,7 +30,7 @@ public class TrailingWhitespaceInspectionTool extends CodeNarcInspectionTool<Tra
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/IllegalClassMemberInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/IllegalClassMemberInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.IllegalClassMemberRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IllegalClassMemberInspectionTool extends CodeNarcInspectionTool<IllegalClassMemberRule> {
@@ -66,7 +66,7 @@ public class IllegalClassMemberInspectionTool extends CodeNarcInspectionTool<Ill
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/IllegalClassReferenceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/IllegalClassReferenceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.IllegalClassReferenceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IllegalClassReferenceInspectionTool extends CodeNarcInspectionTool<IllegalClassReferenceRule> {
@@ -57,7 +57,7 @@ public class IllegalClassReferenceInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/IllegalPackageReferenceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/IllegalPackageReferenceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.IllegalPackageReferenceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IllegalPackageReferenceInspectionTool extends CodeNarcInspectionTool<IllegalPackageReferenceRule> {
@@ -57,7 +57,7 @@ public class IllegalPackageReferenceInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/IllegalRegexInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/IllegalRegexInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.IllegalRegexRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IllegalRegexInspectionTool extends CodeNarcInspectionTool<IllegalRegexRule> {
@@ -39,7 +39,7 @@ public class IllegalRegexInspectionTool extends CodeNarcInspectionTool<IllegalRe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/IllegalStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/IllegalStringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.IllegalStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IllegalStringInspectionTool extends CodeNarcInspectionTool<IllegalStringRule> {
@@ -39,7 +39,7 @@ public class IllegalStringInspectionTool extends CodeNarcInspectionTool<IllegalS
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/IllegalSubclassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/IllegalSubclassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.IllegalSubclassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class IllegalSubclassInspectionTool extends CodeNarcInspectionTool<IllegalSubclassRule> {
@@ -57,7 +57,7 @@ public class IllegalSubclassInspectionTool extends CodeNarcInspectionTool<Illega
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/RequiredRegexInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/RequiredRegexInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.RequiredRegexRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class RequiredRegexInspectionTool extends CodeNarcInspectionTool<RequiredRegexRule> {
@@ -39,7 +39,7 @@ public class RequiredRegexInspectionTool extends CodeNarcInspectionTool<Required
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/RequiredStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/RequiredStringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.RequiredStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class RequiredStringInspectionTool extends CodeNarcInspectionTool<RequiredStringRule> {
@@ -39,7 +39,7 @@ public class RequiredStringInspectionTool extends CodeNarcInspectionTool<Require
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/generic/StatelessClassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/generic/StatelessClassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.generic.StatelessClassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class StatelessClassInspectionTool extends CodeNarcInspectionTool<StatelessClassRule> {
@@ -66,7 +66,7 @@ public class StatelessClassInspectionTool extends CodeNarcInspectionTool<Statele
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainHasEqualsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainHasEqualsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsDomainHasEqualsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsDomainHasEqualsInspectionTool extends CodeNarcInspectionTool<GrailsDomainHasEqualsRule> {
@@ -48,7 +48,7 @@ public class GrailsDomainHasEqualsInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainHasToStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainHasToStringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsDomainHasToStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsDomainHasToStringInspectionTool extends CodeNarcInspectionTool<GrailsDomainHasToStringRule> {
@@ -48,7 +48,7 @@ public class GrailsDomainHasToStringInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainReservedSqlKeywordNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainReservedSqlKeywordNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsDomainReservedSqlKeywordNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsDomainReservedSqlKeywordNameInspectionTool extends CodeNarcInspectionTool<GrailsDomainReservedSqlKeywordNameRule> {
@@ -66,7 +66,7 @@ public class GrailsDomainReservedSqlKeywordNameInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainStringPropertyMaxSizeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainStringPropertyMaxSizeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsDomainStringPropertyMaxSizeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsDomainStringPropertyMaxSizeInspectionTool extends CodeNarcInspectionTool<GrailsDomainStringPropertyMaxSizeRule> {
@@ -48,7 +48,7 @@ public class GrailsDomainStringPropertyMaxSizeInspectionTool extends CodeNarcIns
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainWithServiceReferenceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsDomainWithServiceReferenceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsDomainWithServiceReferenceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsDomainWithServiceReferenceInspectionTool extends CodeNarcInspectionTool<GrailsDomainWithServiceReferenceRule> {
@@ -48,7 +48,7 @@ public class GrailsDomainWithServiceReferenceInspectionTool extends CodeNarcInsp
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsDuplicateConstraintInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsDuplicateConstraintInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsDuplicateConstraintRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsDuplicateConstraintInspectionTool extends CodeNarcInspectionTool<GrailsDuplicateConstraintRule> {
@@ -48,7 +48,7 @@ public class GrailsDuplicateConstraintInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsDuplicateMappingInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsDuplicateMappingInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsDuplicateMappingRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsDuplicateMappingInspectionTool extends CodeNarcInspectionTool<GrailsDuplicateMappingRule> {
@@ -48,7 +48,7 @@ public class GrailsDuplicateMappingInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsMassAssignmentInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsMassAssignmentInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsMassAssignmentRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsMassAssignmentInspectionTool extends CodeNarcInspectionTool<GrailsMassAssignmentRule> {
@@ -48,7 +48,7 @@ public class GrailsMassAssignmentInspectionTool extends CodeNarcInspectionTool<G
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsPublicControllerMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsPublicControllerMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsPublicControllerMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsPublicControllerMethodInspectionTool extends CodeNarcInspectionTool<GrailsPublicControllerMethodRule> {
@@ -57,7 +57,7 @@ public class GrailsPublicControllerMethodInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsServletContextReferenceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsServletContextReferenceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsServletContextReferenceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsServletContextReferenceInspectionTool extends CodeNarcInspectionTool<GrailsServletContextReferenceRule> {
@@ -48,7 +48,7 @@ public class GrailsServletContextReferenceInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/grails/GrailsStatelessServiceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/grails/GrailsStatelessServiceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.grails.GrailsStatelessServiceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GrailsStatelessServiceInspectionTool extends CodeNarcInspectionTool<GrailsStatelessServiceRule> {
@@ -66,7 +66,7 @@ public class GrailsStatelessServiceInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/AssignCollectionSortInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/AssignCollectionSortInspectionTool.java
@@ -9,7 +9,7 @@ import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.idea.quickfix.ReplaceStatementFix;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.AssignCollectionSortRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrMethodCall;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
@@ -50,7 +50,7 @@ public class AssignCollectionSortInspectionTool extends CodeNarcInspectionTool<A
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.singleton(new ReplaceStatementFix(GrMethodCall.class, "sort()", "sort(false)"));
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/AssignCollectionUniqueInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/AssignCollectionUniqueInspectionTool.java
@@ -9,7 +9,7 @@ import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.idea.quickfix.ReplaceStatementFix;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.AssignCollectionUniqueRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrMethodCall;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
@@ -50,7 +50,7 @@ public class AssignCollectionUniqueInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.singleton(new ReplaceStatementFix(GrMethodCall.class, "unique()", "unique(false)"));
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ClosureAsLastMethodParameterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ClosureAsLastMethodParameterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ClosureAsLastMethodParameterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClosureAsLastMethodParameterInspectionTool extends CodeNarcInspectionTool<ClosureAsLastMethodParameterRule> {
@@ -57,7 +57,7 @@ public class ClosureAsLastMethodParameterInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/CollectAllIsDeprecatedInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/CollectAllIsDeprecatedInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.CollectAllIsDeprecatedRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CollectAllIsDeprecatedInspectionTool extends CodeNarcInspectionTool<CollectAllIsDeprecatedRule> {
@@ -48,7 +48,7 @@ public class CollectAllIsDeprecatedInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ConfusingMultipleReturnsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ConfusingMultipleReturnsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ConfusingMultipleReturnsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConfusingMultipleReturnsInspectionTool extends CodeNarcInspectionTool<ConfusingMultipleReturnsRule> {
@@ -48,7 +48,7 @@ public class ConfusingMultipleReturnsInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitArrayListInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitArrayListInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitArrayListInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitArrayListInstantiationInspectionTool extends CodeNarcInspectionTool<ExplicitArrayListInstantiationRule> {
@@ -48,7 +48,7 @@ public class ExplicitArrayListInstantiationInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToAndMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToAndMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToAndMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToAndMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToAndMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToAndMethodInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToCompareToMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToCompareToMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToCompareToMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToCompareToMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToCompareToMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToCompareToMethodInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToDivMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToDivMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToDivMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToDivMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToDivMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToDivMethodInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToEqualsMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToEqualsMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToEqualsMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToEqualsMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToEqualsMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToEqualsMethodInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToGetAtMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToGetAtMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToGetAtMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToGetAtMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToGetAtMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToGetAtMethodInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToLeftShiftMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToLeftShiftMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToLeftShiftMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToLeftShiftMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToLeftShiftMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToLeftShiftMethodInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToMinusMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToMinusMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToMinusMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToMinusMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToMinusMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToMinusMethodInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToModMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToModMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToModMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToModMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToModMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToModMethodInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToMultiplyMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToMultiplyMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToMultiplyMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToMultiplyMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToMultiplyMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToMultiplyMethodInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToOrMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToOrMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToOrMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToOrMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToOrMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToOrMethodInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToPlusMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToPlusMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToPlusMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToPlusMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToPlusMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToPlusMethodInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToPowerMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToPowerMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToPowerMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToPowerMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToPowerMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToPowerMethodInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToPutAtMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToPutAtMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToPutAtMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToPutAtMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToPutAtMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToPutAtMethodInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToRightShiftMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToRightShiftMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToRightShiftMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToRightShiftMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToRightShiftMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToRightShiftMethodInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToXorMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitCallToXorMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitCallToXorMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitCallToXorMethodInspectionTool extends CodeNarcInspectionTool<ExplicitCallToXorMethodRule> {
@@ -57,7 +57,7 @@ public class ExplicitCallToXorMethodInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitHashMapInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitHashMapInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitHashMapInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitHashMapInstantiationInspectionTool extends CodeNarcInspectionTool<ExplicitHashMapInstantiationRule> {
@@ -48,7 +48,7 @@ public class ExplicitHashMapInstantiationInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitHashSetInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitHashSetInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitHashSetInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitHashSetInstantiationInspectionTool extends CodeNarcInspectionTool<ExplicitHashSetInstantiationRule> {
@@ -48,7 +48,7 @@ public class ExplicitHashSetInstantiationInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitLinkedHashMapInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitLinkedHashMapInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitLinkedHashMapInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitLinkedHashMapInstantiationInspectionTool extends CodeNarcInspectionTool<ExplicitLinkedHashMapInstantiationRule> {
@@ -48,7 +48,7 @@ public class ExplicitLinkedHashMapInstantiationInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitLinkedListInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitLinkedListInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitLinkedListInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitLinkedListInstantiationInspectionTool extends CodeNarcInspectionTool<ExplicitLinkedListInstantiationRule> {
@@ -48,7 +48,7 @@ public class ExplicitLinkedListInstantiationInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitStackInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitStackInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitStackInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitStackInstantiationInspectionTool extends CodeNarcInspectionTool<ExplicitStackInstantiationRule> {
@@ -48,7 +48,7 @@ public class ExplicitStackInstantiationInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitTreeSetInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/ExplicitTreeSetInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.ExplicitTreeSetInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ExplicitTreeSetInstantiationInspectionTool extends CodeNarcInspectionTool<ExplicitTreeSetInstantiationRule> {
@@ -48,7 +48,7 @@ public class ExplicitTreeSetInstantiationInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/GStringAsMapKeyInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/GStringAsMapKeyInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.GStringAsMapKeyRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GStringAsMapKeyInspectionTool extends CodeNarcInspectionTool<GStringAsMapKeyRule> {
@@ -48,7 +48,7 @@ public class GStringAsMapKeyInspectionTool extends CodeNarcInspectionTool<GStrin
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/GStringExpressionWithinStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/GStringExpressionWithinStringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.GStringExpressionWithinStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GStringExpressionWithinStringInspectionTool extends CodeNarcInspectionTool<GStringExpressionWithinStringRule> {
@@ -48,7 +48,7 @@ public class GStringExpressionWithinStringInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/GetterMethodCouldBePropertyInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/GetterMethodCouldBePropertyInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.GetterMethodCouldBePropertyRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GetterMethodCouldBePropertyInspectionTool extends CodeNarcInspectionTool<GetterMethodCouldBePropertyRule> {
@@ -57,7 +57,7 @@ public class GetterMethodCouldBePropertyInspectionTool extends CodeNarcInspectio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/GroovyLangImmutableInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/GroovyLangImmutableInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.GroovyLangImmutableRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class GroovyLangImmutableInspectionTool extends CodeNarcInspectionTool<GroovyLangImmutableRule> {
@@ -48,7 +48,7 @@ public class GroovyLangImmutableInspectionTool extends CodeNarcInspectionTool<Gr
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/UseCollectManyInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/UseCollectManyInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.UseCollectManyRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseCollectManyInspectionTool extends CodeNarcInspectionTool<UseCollectManyRule> {
@@ -48,7 +48,7 @@ public class UseCollectManyInspectionTool extends CodeNarcInspectionTool<UseColl
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/groovyism/UseCollectNestedInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/groovyism/UseCollectNestedInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.groovyism.UseCollectNestedRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseCollectNestedInspectionTool extends CodeNarcInspectionTool<UseCollectNestedRule> {
@@ -48,7 +48,7 @@ public class UseCollectNestedInspectionTool extends CodeNarcInspectionTool<UseCo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/imports/DuplicateImportInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/imports/DuplicateImportInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.imports.DuplicateImportRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DuplicateImportInspectionTool extends CodeNarcInspectionTool<DuplicateImportRule> {
@@ -30,7 +30,7 @@ public class DuplicateImportInspectionTool extends CodeNarcInspectionTool<Duplic
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/imports/ImportFromSamePackageInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/imports/ImportFromSamePackageInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.imports.ImportFromSamePackageRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ImportFromSamePackageInspectionTool extends CodeNarcInspectionTool<ImportFromSamePackageRule> {
@@ -30,7 +30,7 @@ public class ImportFromSamePackageInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/imports/ImportFromSunPackagesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/imports/ImportFromSunPackagesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.imports.ImportFromSunPackagesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ImportFromSunPackagesInspectionTool extends CodeNarcInspectionTool<ImportFromSunPackagesRule> {
@@ -48,7 +48,7 @@ public class ImportFromSunPackagesInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/imports/MisorderedStaticImportsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/imports/MisorderedStaticImportsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.imports.MisorderedStaticImportsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MisorderedStaticImportsInspectionTool extends CodeNarcInspectionTool<MisorderedStaticImportsRule> {
@@ -39,7 +39,7 @@ public class MisorderedStaticImportsInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/imports/NoWildcardImportsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/imports/NoWildcardImportsInspectionTool.java
@@ -9,7 +9,7 @@ import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.idea.quickfix.ReplaceOnDemandImportFix;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.imports.NoWildcardImportsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.jetbrains.plugins.groovy.lang.psi.api.toplevel.imports.GrImportStatement;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
@@ -56,9 +56,8 @@ public class NoWildcardImportsInspectionTool extends CodeNarcInspectionTool<NoWi
     }
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
-        if (violatingElement instanceof GrImportStatement) {
-            GrImportStatement importStatement = (GrImportStatement) violatingElement;
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+        if (violatingElement instanceof GrImportStatement importStatement) {
             if (!importStatement.isStatic()) {
                 return Collections.singleton(new ReplaceOnDemandImportFix());
             }

--- a/src/main/java/org/codenarc/idea/inspections/imports/UnnecessaryGroovyImportInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/imports/UnnecessaryGroovyImportInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.imports.UnnecessaryGroovyImportRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryGroovyImportInspectionTool extends CodeNarcInspectionTool<UnnecessaryGroovyImportRule> {
@@ -30,7 +30,7 @@ public class UnnecessaryGroovyImportInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/imports/UnusedImportInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/imports/UnusedImportInspectionTool.java
@@ -10,7 +10,7 @@ import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.idea.quickfix.DeleteElementQuickFix;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.imports.UnusedImportRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnusedImportInspectionTool extends CodeNarcInspectionTool<UnusedImportRule> implements CleanupLocalInspectionTool {
@@ -32,7 +32,7 @@ public class UnusedImportInspectionTool extends CodeNarcInspectionTool<UnusedImp
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.singleton(new DeleteElementQuickFix(violatingElement));
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/jdbc/DirectConnectionManagementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/jdbc/DirectConnectionManagementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.jdbc.DirectConnectionManagementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class DirectConnectionManagementInspectionTool extends CodeNarcInspectionTool<DirectConnectionManagementRule> {
@@ -48,7 +48,7 @@ public class DirectConnectionManagementInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/jdbc/JdbcConnectionReferenceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/jdbc/JdbcConnectionReferenceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.jdbc.JdbcConnectionReferenceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JdbcConnectionReferenceInspectionTool extends CodeNarcInspectionTool<JdbcConnectionReferenceRule> {
@@ -48,7 +48,7 @@ public class JdbcConnectionReferenceInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/jdbc/JdbcResultSetReferenceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/jdbc/JdbcResultSetReferenceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.jdbc.JdbcResultSetReferenceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JdbcResultSetReferenceInspectionTool extends CodeNarcInspectionTool<JdbcResultSetReferenceRule> {
@@ -48,7 +48,7 @@ public class JdbcResultSetReferenceInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/jdbc/JdbcStatementReferenceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/jdbc/JdbcStatementReferenceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.jdbc.JdbcStatementReferenceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JdbcStatementReferenceInspectionTool extends CodeNarcInspectionTool<JdbcStatementReferenceRule> {
@@ -48,7 +48,7 @@ public class JdbcStatementReferenceInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/jenkins/ClosureInGStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/jenkins/ClosureInGStringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.jenkins.ClosureInGStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClosureInGStringInspectionTool extends CodeNarcInspectionTool<ClosureInGStringRule> {
@@ -48,7 +48,7 @@ public class ClosureInGStringInspectionTool extends CodeNarcInspectionTool<Closu
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/ChainedTestInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/ChainedTestInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.ChainedTestRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ChainedTestInspectionTool extends CodeNarcInspectionTool<ChainedTestRule> {
@@ -48,7 +48,7 @@ public class ChainedTestInspectionTool extends CodeNarcInspectionTool<ChainedTes
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/CoupledTestCaseInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/CoupledTestCaseInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.CoupledTestCaseRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CoupledTestCaseInspectionTool extends CodeNarcInspectionTool<CoupledTestCaseRule> {
@@ -48,7 +48,7 @@ public class CoupledTestCaseInspectionTool extends CodeNarcInspectionTool<Couple
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitAssertAlwaysFailsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitAssertAlwaysFailsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitAssertAlwaysFailsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitAssertAlwaysFailsInspectionTool extends CodeNarcInspectionTool<JUnitAssertAlwaysFailsRule> {
@@ -48,7 +48,7 @@ public class JUnitAssertAlwaysFailsInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitAssertAlwaysSucceedsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitAssertAlwaysSucceedsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitAssertAlwaysSucceedsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitAssertAlwaysSucceedsInspectionTool extends CodeNarcInspectionTool<JUnitAssertAlwaysSucceedsRule> {
@@ -48,7 +48,7 @@ public class JUnitAssertAlwaysSucceedsInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitFailWithoutMessageInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitFailWithoutMessageInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitFailWithoutMessageRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitFailWithoutMessageInspectionTool extends CodeNarcInspectionTool<JUnitFailWithoutMessageRule> {
@@ -48,7 +48,7 @@ public class JUnitFailWithoutMessageInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitLostTestInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitLostTestInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitLostTestRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitLostTestInspectionTool extends CodeNarcInspectionTool<JUnitLostTestRule> {
@@ -48,7 +48,7 @@ public class JUnitLostTestInspectionTool extends CodeNarcInspectionTool<JUnitLos
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitPublicFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitPublicFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitPublicFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitPublicFieldInspectionTool extends CodeNarcInspectionTool<JUnitPublicFieldRule> {
@@ -48,7 +48,7 @@ public class JUnitPublicFieldInspectionTool extends CodeNarcInspectionTool<JUnit
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitPublicNonTestMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitPublicNonTestMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitPublicNonTestMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitPublicNonTestMethodInspectionTool extends CodeNarcInspectionTool<JUnitPublicNonTestMethodRule> {
@@ -48,7 +48,7 @@ public class JUnitPublicNonTestMethodInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitPublicPropertyInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitPublicPropertyInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitPublicPropertyRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitPublicPropertyInspectionTool extends CodeNarcInspectionTool<JUnitPublicPropertyRule> {
@@ -57,7 +57,7 @@ public class JUnitPublicPropertyInspectionTool extends CodeNarcInspectionTool<JU
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitSetUpCallsSuperInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitSetUpCallsSuperInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitSetUpCallsSuperRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitSetUpCallsSuperInspectionTool extends CodeNarcInspectionTool<JUnitSetUpCallsSuperRule> {
@@ -48,7 +48,7 @@ public class JUnitSetUpCallsSuperInspectionTool extends CodeNarcInspectionTool<J
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitStyleAssertionsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitStyleAssertionsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitStyleAssertionsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitStyleAssertionsInspectionTool extends CodeNarcInspectionTool<JUnitStyleAssertionsRule> {
@@ -48,7 +48,7 @@ public class JUnitStyleAssertionsInspectionTool extends CodeNarcInspectionTool<J
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitTearDownCallsSuperInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitTearDownCallsSuperInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitTearDownCallsSuperRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitTearDownCallsSuperInspectionTool extends CodeNarcInspectionTool<JUnitTearDownCallsSuperRule> {
@@ -48,7 +48,7 @@ public class JUnitTearDownCallsSuperInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitTestMethodWithoutAssertInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitTestMethodWithoutAssertInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitTestMethodWithoutAssertRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitTestMethodWithoutAssertInspectionTool extends CodeNarcInspectionTool<JUnitTestMethodWithoutAssertRule> {
@@ -57,7 +57,7 @@ public class JUnitTestMethodWithoutAssertInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitUnnecessarySetUpInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitUnnecessarySetUpInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitUnnecessarySetUpRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitUnnecessarySetUpInspectionTool extends CodeNarcInspectionTool<JUnitUnnecessarySetUpRule> {
@@ -48,7 +48,7 @@ public class JUnitUnnecessarySetUpInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitUnnecessaryTearDownInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitUnnecessaryTearDownInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitUnnecessaryTearDownRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitUnnecessaryTearDownInspectionTool extends CodeNarcInspectionTool<JUnitUnnecessaryTearDownRule> {
@@ -48,7 +48,7 @@ public class JUnitUnnecessaryTearDownInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/JUnitUnnecessaryThrowsExceptionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/JUnitUnnecessaryThrowsExceptionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.JUnitUnnecessaryThrowsExceptionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JUnitUnnecessaryThrowsExceptionInspectionTool extends CodeNarcInspectionTool<JUnitUnnecessaryThrowsExceptionRule> {
@@ -48,7 +48,7 @@ public class JUnitUnnecessaryThrowsExceptionInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/SpockIgnoreRestUsedInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/SpockIgnoreRestUsedInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.SpockIgnoreRestUsedRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpockIgnoreRestUsedInspectionTool extends CodeNarcInspectionTool<SpockIgnoreRestUsedRule> {
@@ -66,7 +66,7 @@ public class SpockIgnoreRestUsedInspectionTool extends CodeNarcInspectionTool<Sp
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/SpockMissingAssertInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/SpockMissingAssertInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.SpockMissingAssertRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SpockMissingAssertInspectionTool extends CodeNarcInspectionTool<SpockMissingAssertRule> {
@@ -66,7 +66,7 @@ public class SpockMissingAssertInspectionTool extends CodeNarcInspectionTool<Spo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/UnnecessaryFailInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/UnnecessaryFailInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.UnnecessaryFailRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryFailInspectionTool extends CodeNarcInspectionTool<UnnecessaryFailRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryFailInspectionTool extends CodeNarcInspectionTool<Unnece
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/UseAssertEqualsInsteadOfAssertTrueInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/UseAssertEqualsInsteadOfAssertTrueInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.UseAssertEqualsInsteadOfAssertTrueRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseAssertEqualsInsteadOfAssertTrueInspectionTool extends CodeNarcInspectionTool<UseAssertEqualsInsteadOfAssertTrueRule> {
@@ -48,7 +48,7 @@ public class UseAssertEqualsInsteadOfAssertTrueInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/UseAssertFalseInsteadOfNegationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/UseAssertFalseInsteadOfNegationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.UseAssertFalseInsteadOfNegationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseAssertFalseInsteadOfNegationInspectionTool extends CodeNarcInspectionTool<UseAssertFalseInsteadOfNegationRule> {
@@ -48,7 +48,7 @@ public class UseAssertFalseInsteadOfNegationInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/UseAssertNullInsteadOfAssertEqualsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/UseAssertNullInsteadOfAssertEqualsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.UseAssertNullInsteadOfAssertEqualsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseAssertNullInsteadOfAssertEqualsInspectionTool extends CodeNarcInspectionTool<UseAssertNullInsteadOfAssertEqualsRule> {
@@ -48,7 +48,7 @@ public class UseAssertNullInsteadOfAssertEqualsInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/UseAssertSameInsteadOfAssertTrueInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/UseAssertSameInsteadOfAssertTrueInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.UseAssertSameInsteadOfAssertTrueRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseAssertSameInsteadOfAssertTrueInspectionTool extends CodeNarcInspectionTool<UseAssertSameInsteadOfAssertTrueRule> {
@@ -48,7 +48,7 @@ public class UseAssertSameInsteadOfAssertTrueInspectionTool extends CodeNarcInsp
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/UseAssertTrueInsteadOfAssertEqualsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/UseAssertTrueInsteadOfAssertEqualsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.UseAssertTrueInsteadOfAssertEqualsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseAssertTrueInsteadOfAssertEqualsInspectionTool extends CodeNarcInspectionTool<UseAssertTrueInsteadOfAssertEqualsRule> {
@@ -57,7 +57,7 @@ public class UseAssertTrueInsteadOfAssertEqualsInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/junit/UseAssertTrueInsteadOfNegationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/junit/UseAssertTrueInsteadOfNegationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.junit.UseAssertTrueInsteadOfNegationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UseAssertTrueInsteadOfNegationInspectionTool extends CodeNarcInspectionTool<UseAssertTrueInsteadOfNegationRule> {
@@ -48,7 +48,7 @@ public class UseAssertTrueInsteadOfNegationInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/logging/LoggerForDifferentClassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/logging/LoggerForDifferentClassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.logging.LoggerForDifferentClassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class LoggerForDifferentClassInspectionTool extends CodeNarcInspectionTool<LoggerForDifferentClassRule> {
@@ -57,7 +57,7 @@ public class LoggerForDifferentClassInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/logging/LoggerWithWrongModifiersInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/logging/LoggerWithWrongModifiersInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.logging.LoggerWithWrongModifiersRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class LoggerWithWrongModifiersInspectionTool extends CodeNarcInspectionTool<LoggerWithWrongModifiersRule> {
@@ -66,7 +66,7 @@ public class LoggerWithWrongModifiersInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/logging/LoggingSwallowsStacktraceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/logging/LoggingSwallowsStacktraceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.logging.LoggingSwallowsStacktraceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class LoggingSwallowsStacktraceInspectionTool extends CodeNarcInspectionTool<LoggingSwallowsStacktraceRule> {
@@ -48,7 +48,7 @@ public class LoggingSwallowsStacktraceInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/logging/MultipleLoggersInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/logging/MultipleLoggersInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.logging.MultipleLoggersRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MultipleLoggersInspectionTool extends CodeNarcInspectionTool<MultipleLoggersRule> {
@@ -48,7 +48,7 @@ public class MultipleLoggersInspectionTool extends CodeNarcInspectionTool<Multip
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/logging/PrintStackTraceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/logging/PrintStackTraceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.logging.PrintStackTraceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PrintStackTraceInspectionTool extends CodeNarcInspectionTool<PrintStackTraceRule> {
@@ -48,7 +48,7 @@ public class PrintStackTraceInspectionTool extends CodeNarcInspectionTool<PrintS
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/logging/PrintlnInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/logging/PrintlnInspectionTool.java
@@ -9,7 +9,7 @@ import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.idea.quickfix.ReplacePrintlnWithAnnotationFix;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.logging.PrintlnRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PrintlnInspectionTool extends CodeNarcInspectionTool<PrintlnRule> {
@@ -49,7 +49,7 @@ public class PrintlnInspectionTool extends CodeNarcInspectionTool<PrintlnRule> {
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.singleton(new ReplacePrintlnWithAnnotationFix());
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/logging/SystemErrPrintInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/logging/SystemErrPrintInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.logging.SystemErrPrintRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SystemErrPrintInspectionTool extends CodeNarcInspectionTool<SystemErrPrintRule> {
@@ -48,7 +48,7 @@ public class SystemErrPrintInspectionTool extends CodeNarcInspectionTool<SystemE
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/logging/SystemOutPrintInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/logging/SystemOutPrintInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.logging.SystemOutPrintRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SystemOutPrintInspectionTool extends CodeNarcInspectionTool<SystemOutPrintRule> {
@@ -48,7 +48,7 @@ public class SystemOutPrintInspectionTool extends CodeNarcInspectionTool<SystemO
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/AbstractClassNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/AbstractClassNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.AbstractClassNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class AbstractClassNameInspectionTool extends CodeNarcInspectionTool<AbstractClassNameRule> {
@@ -57,7 +57,7 @@ public class AbstractClassNameInspectionTool extends CodeNarcInspectionTool<Abst
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/ClassNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/ClassNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.ClassNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClassNameInspectionTool extends CodeNarcInspectionTool<ClassNameRule> {
@@ -57,7 +57,7 @@ public class ClassNameInspectionTool extends CodeNarcInspectionTool<ClassNameRul
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/ClassNameSameAsFilenameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/ClassNameSameAsFilenameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.ClassNameSameAsFilenameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClassNameSameAsFilenameInspectionTool extends CodeNarcInspectionTool<ClassNameSameAsFilenameRule> {
@@ -30,7 +30,7 @@ public class ClassNameSameAsFilenameInspectionTool extends CodeNarcInspectionToo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/ClassNameSameAsSuperclassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/ClassNameSameAsSuperclassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.ClassNameSameAsSuperclassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClassNameSameAsSuperclassInspectionTool extends CodeNarcInspectionTool<ClassNameSameAsSuperclassRule> {
@@ -48,7 +48,7 @@ public class ClassNameSameAsSuperclassInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/ConfusingMethodNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/ConfusingMethodNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.ConfusingMethodNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConfusingMethodNameInspectionTool extends CodeNarcInspectionTool<ConfusingMethodNameRule> {
@@ -48,7 +48,7 @@ public class ConfusingMethodNameInspectionTool extends CodeNarcInspectionTool<Co
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/FactoryMethodNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/FactoryMethodNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.FactoryMethodNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class FactoryMethodNameInspectionTool extends CodeNarcInspectionTool<FactoryMethodNameRule> {
@@ -57,7 +57,7 @@ public class FactoryMethodNameInspectionTool extends CodeNarcInspectionTool<Fact
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/FieldNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/FieldNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.FieldNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class FieldNameInspectionTool extends CodeNarcInspectionTool<FieldNameRule> {
@@ -102,7 +102,7 @@ public class FieldNameInspectionTool extends CodeNarcInspectionTool<FieldNameRul
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/InterfaceNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/InterfaceNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.InterfaceNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class InterfaceNameInspectionTool extends CodeNarcInspectionTool<InterfaceNameRule> {
@@ -57,7 +57,7 @@ public class InterfaceNameInspectionTool extends CodeNarcInspectionTool<Interfac
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/InterfaceNameSameAsSuperInterfaceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/InterfaceNameSameAsSuperInterfaceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.InterfaceNameSameAsSuperInterfaceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class InterfaceNameSameAsSuperInterfaceInspectionTool extends CodeNarcInspectionTool<InterfaceNameSameAsSuperInterfaceRule> {
@@ -48,7 +48,7 @@ public class InterfaceNameSameAsSuperInterfaceInspectionTool extends CodeNarcIns
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/MethodNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/MethodNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.MethodNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MethodNameInspectionTool extends CodeNarcInspectionTool<MethodNameRule> {
@@ -66,7 +66,7 @@ public class MethodNameInspectionTool extends CodeNarcInspectionTool<MethodNameR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/ObjectOverrideMisspelledMethodNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/ObjectOverrideMisspelledMethodNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.ObjectOverrideMisspelledMethodNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ObjectOverrideMisspelledMethodNameInspectionTool extends CodeNarcInspectionTool<ObjectOverrideMisspelledMethodNameRule> {
@@ -48,7 +48,7 @@ public class ObjectOverrideMisspelledMethodNameInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/PackageNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/PackageNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.PackageNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PackageNameInspectionTool extends CodeNarcInspectionTool<PackageNameRule> {
@@ -66,7 +66,7 @@ public class PackageNameInspectionTool extends CodeNarcInspectionTool<PackageNam
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/PackageNameMatchesFilePathInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/PackageNameMatchesFilePathInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.PackageNameMatchesFilePathRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PackageNameMatchesFilePathInspectionTool extends CodeNarcInspectionTool<PackageNameMatchesFilePathRule> {
@@ -39,7 +39,7 @@ public class PackageNameMatchesFilePathInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/ParameterNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/ParameterNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.ParameterNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ParameterNameInspectionTool extends CodeNarcInspectionTool<ParameterNameRule> {
@@ -66,7 +66,7 @@ public class ParameterNameInspectionTool extends CodeNarcInspectionTool<Paramete
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/PropertyNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/PropertyNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.PropertyNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PropertyNameInspectionTool extends CodeNarcInspectionTool<PropertyNameRule> {
@@ -93,7 +93,7 @@ public class PropertyNameInspectionTool extends CodeNarcInspectionTool<PropertyN
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/naming/VariableNameInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/naming/VariableNameInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.naming.VariableNameRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class VariableNameInspectionTool extends CodeNarcInspectionTool<VariableNameRule> {
@@ -75,7 +75,7 @@ public class VariableNameInspectionTool extends CodeNarcInspectionTool<VariableN
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/FileCreateTempFileInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/FileCreateTempFileInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.FileCreateTempFileRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class FileCreateTempFileInspectionTool extends CodeNarcInspectionTool<FileCreateTempFileRule> {
@@ -48,7 +48,7 @@ public class FileCreateTempFileInspectionTool extends CodeNarcInspectionTool<Fil
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/InsecureRandomInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/InsecureRandomInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.InsecureRandomRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class InsecureRandomInspectionTool extends CodeNarcInspectionTool<InsecureRandomRule> {
@@ -48,7 +48,7 @@ public class InsecureRandomInspectionTool extends CodeNarcInspectionTool<Insecur
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/JavaIoPackageAccessInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/JavaIoPackageAccessInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.JavaIoPackageAccessRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class JavaIoPackageAccessInspectionTool extends CodeNarcInspectionTool<JavaIoPackageAccessRule> {
@@ -48,7 +48,7 @@ public class JavaIoPackageAccessInspectionTool extends CodeNarcInspectionTool<Ja
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/NonFinalPublicFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/NonFinalPublicFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.NonFinalPublicFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NonFinalPublicFieldInspectionTool extends CodeNarcInspectionTool<NonFinalPublicFieldRule> {
@@ -48,7 +48,7 @@ public class NonFinalPublicFieldInspectionTool extends CodeNarcInspectionTool<No
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/NonFinalSubclassOfSensitiveInterfaceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/NonFinalSubclassOfSensitiveInterfaceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.NonFinalSubclassOfSensitiveInterfaceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NonFinalSubclassOfSensitiveInterfaceInspectionTool extends CodeNarcInspectionTool<NonFinalSubclassOfSensitiveInterfaceRule> {
@@ -48,7 +48,7 @@ public class NonFinalSubclassOfSensitiveInterfaceInspectionTool extends CodeNarc
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/ObjectFinalizeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/ObjectFinalizeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.ObjectFinalizeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ObjectFinalizeInspectionTool extends CodeNarcInspectionTool<ObjectFinalizeRule> {
@@ -48,7 +48,7 @@ public class ObjectFinalizeInspectionTool extends CodeNarcInspectionTool<ObjectF
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/PublicFinalizeMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/PublicFinalizeMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.PublicFinalizeMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class PublicFinalizeMethodInspectionTool extends CodeNarcInspectionTool<PublicFinalizeMethodRule> {
@@ -48,7 +48,7 @@ public class PublicFinalizeMethodInspectionTool extends CodeNarcInspectionTool<P
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/SystemExitInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/SystemExitInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.SystemExitRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SystemExitInspectionTool extends CodeNarcInspectionTool<SystemExitRule> {
@@ -48,7 +48,7 @@ public class SystemExitInspectionTool extends CodeNarcInspectionTool<SystemExitR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/security/UnsafeArrayDeclarationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/security/UnsafeArrayDeclarationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.security.UnsafeArrayDeclarationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnsafeArrayDeclarationInspectionTool extends CodeNarcInspectionTool<UnsafeArrayDeclarationRule> {
@@ -48,7 +48,7 @@ public class UnsafeArrayDeclarationInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/serialization/EnumCustomSerializationIgnoredInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/serialization/EnumCustomSerializationIgnoredInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.serialization.EnumCustomSerializationIgnoredRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class EnumCustomSerializationIgnoredInspectionTool extends CodeNarcInspectionTool<EnumCustomSerializationIgnoredRule> {
@@ -48,7 +48,7 @@ public class EnumCustomSerializationIgnoredInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/serialization/SerialPersistentFieldsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/serialization/SerialPersistentFieldsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.serialization.SerialPersistentFieldsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SerialPersistentFieldsInspectionTool extends CodeNarcInspectionTool<SerialPersistentFieldsRule> {
@@ -48,7 +48,7 @@ public class SerialPersistentFieldsInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/serialization/SerialVersionUIDInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/serialization/SerialVersionUIDInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.serialization.SerialVersionUIDRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SerialVersionUIDInspectionTool extends CodeNarcInspectionTool<SerialVersionUIDRule> {
@@ -48,7 +48,7 @@ public class SerialVersionUIDInspectionTool extends CodeNarcInspectionTool<Seria
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/serialization/SerializableClassMustDefineSerialVersionUIDInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/serialization/SerializableClassMustDefineSerialVersionUIDInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.serialization.SerializableClassMustDefineSerialVersionUIDRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class SerializableClassMustDefineSerialVersionUIDInspectionTool extends CodeNarcInspectionTool<SerializableClassMustDefineSerialVersionUIDRule> {
@@ -48,7 +48,7 @@ public class SerializableClassMustDefineSerialVersionUIDInspectionTool extends C
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/size/AbcMetricInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/size/AbcMetricInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.size.AbcMetricRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class AbcMetricInspectionTool extends CodeNarcInspectionTool<AbcMetricRule> {
@@ -84,7 +84,7 @@ public class AbcMetricInspectionTool extends CodeNarcInspectionTool<AbcMetricRul
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/size/ClassSizeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/size/ClassSizeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.size.ClassSizeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ClassSizeInspectionTool extends CodeNarcInspectionTool<ClassSizeRule> {
@@ -57,7 +57,7 @@ public class ClassSizeInspectionTool extends CodeNarcInspectionTool<ClassSizeRul
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/size/CrapMetricInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/size/CrapMetricInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.size.CrapMetricRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CrapMetricInspectionTool extends CodeNarcInspectionTool<CrapMetricRule> {
@@ -93,7 +93,7 @@ public class CrapMetricInspectionTool extends CodeNarcInspectionTool<CrapMetricR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/size/CyclomaticComplexityInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/size/CyclomaticComplexityInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.size.CyclomaticComplexityRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class CyclomaticComplexityInspectionTool extends CodeNarcInspectionTool<CyclomaticComplexityRule> {
@@ -84,7 +84,7 @@ public class CyclomaticComplexityInspectionTool extends CodeNarcInspectionTool<C
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/size/MethodCountInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/size/MethodCountInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.size.MethodCountRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MethodCountInspectionTool extends CodeNarcInspectionTool<MethodCountRule> {
@@ -57,7 +57,7 @@ public class MethodCountInspectionTool extends CodeNarcInspectionTool<MethodCoun
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/size/MethodSizeInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/size/MethodSizeInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.size.MethodSizeRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class MethodSizeInspectionTool extends CodeNarcInspectionTool<MethodSizeRule> {
@@ -66,7 +66,7 @@ public class MethodSizeInspectionTool extends CodeNarcInspectionTool<MethodSizeR
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/size/NestedBlockDepthInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/size/NestedBlockDepthInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.size.NestedBlockDepthRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class NestedBlockDepthInspectionTool extends CodeNarcInspectionTool<NestedBlockDepthRule> {
@@ -66,7 +66,7 @@ public class NestedBlockDepthInspectionTool extends CodeNarcInspectionTool<Neste
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/size/ParameterCountInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/size/ParameterCountInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.size.ParameterCountRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ParameterCountInspectionTool extends CodeNarcInspectionTool<ParameterCountRule> {
@@ -66,7 +66,7 @@ public class ParameterCountInspectionTool extends CodeNarcInspectionTool<Paramet
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/AddEmptyStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/AddEmptyStringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.AddEmptyStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class AddEmptyStringInspectionTool extends CodeNarcInspectionTool<AddEmptyStringRule> {
@@ -48,7 +48,7 @@ public class AddEmptyStringInspectionTool extends CodeNarcInspectionTool<AddEmpt
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/ConsecutiveLiteralAppendsInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/ConsecutiveLiteralAppendsInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.ConsecutiveLiteralAppendsRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConsecutiveLiteralAppendsInspectionTool extends CodeNarcInspectionTool<ConsecutiveLiteralAppendsRule> {
@@ -48,7 +48,7 @@ public class ConsecutiveLiteralAppendsInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/ConsecutiveStringConcatenationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/ConsecutiveStringConcatenationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.ConsecutiveStringConcatenationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class ConsecutiveStringConcatenationInspectionTool extends CodeNarcInspectionTool<ConsecutiveStringConcatenationRule> {
@@ -48,7 +48,7 @@ public class ConsecutiveStringConcatenationInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryBigDecimalInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryBigDecimalInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryBigDecimalInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryBigDecimalInstantiationInspectionTool extends CodeNarcInspectionTool<UnnecessaryBigDecimalInstantiationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryBigDecimalInstantiationInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryBigIntegerInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryBigIntegerInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryBigIntegerInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryBigIntegerInstantiationInspectionTool extends CodeNarcInspectionTool<UnnecessaryBigIntegerInstantiationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryBigIntegerInstantiationInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryBooleanExpressionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryBooleanExpressionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryBooleanExpressionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryBooleanExpressionInspectionTool extends CodeNarcInspectionTool<UnnecessaryBooleanExpressionRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryBooleanExpressionInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryBooleanInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryBooleanInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryBooleanInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryBooleanInstantiationInspectionTool extends CodeNarcInspectionTool<UnnecessaryBooleanInstantiationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryBooleanInstantiationInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCallForLastElementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCallForLastElementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryCallForLastElementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryCallForLastElementInspectionTool extends CodeNarcInspectionTool<UnnecessaryCallForLastElementRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryCallForLastElementInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCallToSubstringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCallToSubstringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryCallToSubstringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryCallToSubstringInspectionTool extends CodeNarcInspectionTool<UnnecessaryCallToSubstringRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryCallToSubstringInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCastInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCastInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryCastRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryCastInspectionTool extends CodeNarcInspectionTool<UnnecessaryCastRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryCastInspectionTool extends CodeNarcInspectionTool<Unnece
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCatchBlockInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCatchBlockInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryCatchBlockRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryCatchBlockInspectionTool extends CodeNarcInspectionTool<UnnecessaryCatchBlockRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryCatchBlockInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCollectCallInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCollectCallInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryCollectCallRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryCollectCallInspectionTool extends CodeNarcInspectionTool<UnnecessaryCollectCallRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryCollectCallInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCollectionCallInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryCollectionCallInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryCollectionCallRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryCollectionCallInspectionTool extends CodeNarcInspectionTool<UnnecessaryCollectionCallRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryCollectionCallInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryConstructorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryConstructorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryConstructorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryConstructorInspectionTool extends CodeNarcInspectionTool<UnnecessaryConstructorRule> {
@@ -57,7 +57,7 @@ public class UnnecessaryConstructorInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDefInFieldDeclarationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDefInFieldDeclarationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryDefInFieldDeclarationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryDefInFieldDeclarationInspectionTool extends CodeNarcInspectionTool<UnnecessaryDefInFieldDeclarationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryDefInFieldDeclarationInspectionTool extends CodeNarcInsp
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDefInMethodDeclarationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDefInMethodDeclarationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryDefInMethodDeclarationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryDefInMethodDeclarationInspectionTool extends CodeNarcInspectionTool<UnnecessaryDefInMethodDeclarationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryDefInMethodDeclarationInspectionTool extends CodeNarcIns
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDefInVariableDeclarationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDefInVariableDeclarationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryDefInVariableDeclarationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryDefInVariableDeclarationInspectionTool extends CodeNarcInspectionTool<UnnecessaryDefInVariableDeclarationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryDefInVariableDeclarationInspectionTool extends CodeNarcI
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDotClassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDotClassInspectionTool.java
@@ -11,7 +11,7 @@ import org.codenarc.idea.quickfix.IntentionQuickFix;
 import org.codenarc.idea.quickfix.RemoveRedundantClassPropertyReusableIntention;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryDotClassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryDotClassInspectionTool extends CodeNarcInspectionTool<UnnecessaryDotClassRule> implements CleanupLocalInspectionTool {
@@ -51,7 +51,7 @@ public class UnnecessaryDotClassInspectionTool extends CodeNarcInspectionTool<Un
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.singleton(IntentionQuickFix.from(new RemoveRedundantClassPropertyReusableIntention()));
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDoubleInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryDoubleInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryDoubleInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryDoubleInstantiationInspectionTool extends CodeNarcInspectionTool<UnnecessaryDoubleInstantiationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryDoubleInstantiationInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryElseStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryElseStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryElseStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryElseStatementInspectionTool extends CodeNarcInspectionTool<UnnecessaryElseStatementRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryElseStatementInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryFinalOnPrivateMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryFinalOnPrivateMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryFinalOnPrivateMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryFinalOnPrivateMethodInspectionTool extends CodeNarcInspectionTool<UnnecessaryFinalOnPrivateMethodRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryFinalOnPrivateMethodInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryFloatInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryFloatInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryFloatInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryFloatInstantiationInspectionTool extends CodeNarcInspectionTool<UnnecessaryFloatInstantiationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryFloatInstantiationInspectionTool extends CodeNarcInspect
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryGStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryGStringInspectionTool.java
@@ -11,7 +11,7 @@ import org.codenarc.idea.quickfix.ConvertGStringToStringReusableIntention;
 import org.codenarc.idea.quickfix.IntentionQuickFix;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryGStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryGStringInspectionTool extends CodeNarcInspectionTool<UnnecessaryGStringRule> implements CleanupLocalInspectionTool {
@@ -51,7 +51,7 @@ public class UnnecessaryGStringInspectionTool extends CodeNarcInspectionTool<Unn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
       return Collections.singleton(IntentionQuickFix.from(new ConvertGStringToStringReusableIntention()));
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryGetterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryGetterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryGetterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryGetterInspectionTool extends CodeNarcInspectionTool<UnnecessaryGetterRule> {
@@ -66,7 +66,7 @@ public class UnnecessaryGetterInspectionTool extends CodeNarcInspectionTool<Unne
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryIfStatementInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryIfStatementInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryIfStatementRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryIfStatementInspectionTool extends CodeNarcInspectionTool<UnnecessaryIfStatementRule> {
@@ -57,7 +57,7 @@ public class UnnecessaryIfStatementInspectionTool extends CodeNarcInspectionTool
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryInstanceOfCheckInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryInstanceOfCheckInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryInstanceOfCheckRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryInstanceOfCheckInspectionTool extends CodeNarcInspectionTool<UnnecessaryInstanceOfCheckRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryInstanceOfCheckInspectionTool extends CodeNarcInspection
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryInstantiationToGetClassInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryInstantiationToGetClassInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryInstantiationToGetClassRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryInstantiationToGetClassInspectionTool extends CodeNarcInspectionTool<UnnecessaryInstantiationToGetClassRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryInstantiationToGetClassInspectionTool extends CodeNarcIn
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryIntegerInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryIntegerInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryIntegerInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryIntegerInstantiationInspectionTool extends CodeNarcInspectionTool<UnnecessaryIntegerInstantiationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryIntegerInstantiationInspectionTool extends CodeNarcInspe
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryLongInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryLongInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryLongInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryLongInstantiationInspectionTool extends CodeNarcInspectionTool<UnnecessaryLongInstantiationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryLongInstantiationInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryModOneInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryModOneInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryModOneRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryModOneInspectionTool extends CodeNarcInspectionTool<UnnecessaryModOneRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryModOneInspectionTool extends CodeNarcInspectionTool<Unne
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryNullCheckBeforeInstanceOfInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryNullCheckBeforeInstanceOfInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryNullCheckBeforeInstanceOfRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryNullCheckBeforeInstanceOfInspectionTool extends CodeNarcInspectionTool<UnnecessaryNullCheckBeforeInstanceOfRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryNullCheckBeforeInstanceOfInspectionTool extends CodeNarc
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryNullCheckInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryNullCheckInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryNullCheckRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryNullCheckInspectionTool extends CodeNarcInspectionTool<UnnecessaryNullCheckRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryNullCheckInspectionTool extends CodeNarcInspectionTool<U
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryObjectReferencesInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryObjectReferencesInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryObjectReferencesRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryObjectReferencesInspectionTool extends CodeNarcInspectionTool<UnnecessaryObjectReferencesRule> {
@@ -57,7 +57,7 @@ public class UnnecessaryObjectReferencesInspectionTool extends CodeNarcInspectio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryOverridingMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryOverridingMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryOverridingMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryOverridingMethodInspectionTool extends CodeNarcInspectionTool<UnnecessaryOverridingMethodRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryOverridingMethodInspectionTool extends CodeNarcInspectio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryPackageReferenceInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryPackageReferenceInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryPackageReferenceRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryPackageReferenceInspectionTool extends CodeNarcInspectionTool<UnnecessaryPackageReferenceRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryPackageReferenceInspectionTool extends CodeNarcInspectio
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryParenthesesForMethodCallWithClosureInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryParenthesesForMethodCallWithClosureInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryParenthesesForMethodCallWithClosureRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryParenthesesForMethodCallWithClosureInspectionTool extends CodeNarcInspectionTool<UnnecessaryParenthesesForMethodCallWithClosureRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryParenthesesForMethodCallWithClosureInspectionTool extend
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryPublicModifierInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryPublicModifierInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryPublicModifierRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryPublicModifierInspectionTool extends CodeNarcInspectionTool<UnnecessaryPublicModifierRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryPublicModifierInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryReturnKeywordInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryReturnKeywordInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryReturnKeywordRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryReturnKeywordInspectionTool extends CodeNarcInspectionTool<UnnecessaryReturnKeywordRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryReturnKeywordInspectionTool extends CodeNarcInspectionTo
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessarySafeNavigationOperatorInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessarySafeNavigationOperatorInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessarySafeNavigationOperatorRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessarySafeNavigationOperatorInspectionTool extends CodeNarcInspectionTool<UnnecessarySafeNavigationOperatorRule> {
@@ -48,7 +48,7 @@ public class UnnecessarySafeNavigationOperatorInspectionTool extends CodeNarcIns
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessarySelfAssignmentInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessarySelfAssignmentInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessarySelfAssignmentRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessarySelfAssignmentInspectionTool extends CodeNarcInspectionTool<UnnecessarySelfAssignmentRule> {
@@ -48,7 +48,7 @@ public class UnnecessarySelfAssignmentInspectionTool extends CodeNarcInspectionT
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessarySemicolonInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessarySemicolonInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessarySemicolonRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessarySemicolonInspectionTool extends CodeNarcInspectionTool<UnnecessarySemicolonRule> {
@@ -48,7 +48,7 @@ public class UnnecessarySemicolonInspectionTool extends CodeNarcInspectionTool<U
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessarySetterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessarySetterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessarySetterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessarySetterInspectionTool extends CodeNarcInspectionTool<UnnecessarySetterRule> {
@@ -48,7 +48,7 @@ public class UnnecessarySetterInspectionTool extends CodeNarcInspectionTool<Unne
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryStringInstantiationInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryStringInstantiationInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryStringInstantiationRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryStringInstantiationInspectionTool extends CodeNarcInspectionTool<UnnecessaryStringInstantiationRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryStringInstantiationInspectionTool extends CodeNarcInspec
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryTernaryExpressionInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryTernaryExpressionInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryTernaryExpressionRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryTernaryExpressionInspectionTool extends CodeNarcInspectionTool<UnnecessaryTernaryExpressionRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryTernaryExpressionInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryToStringInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryToStringInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryToStringRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryToStringInspectionTool extends CodeNarcInspectionTool<UnnecessaryToStringRule> {
@@ -57,7 +57,7 @@ public class UnnecessaryToStringInspectionTool extends CodeNarcInspectionTool<Un
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryTransientModifierInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unnecessary/UnnecessaryTransientModifierInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unnecessary.UnnecessaryTransientModifierRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnnecessaryTransientModifierInspectionTool extends CodeNarcInspectionTool<UnnecessaryTransientModifierRule> {
@@ -48,7 +48,7 @@ public class UnnecessaryTransientModifierInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unused/UnusedArrayInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unused/UnusedArrayInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unused.UnusedArrayRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnusedArrayInspectionTool extends CodeNarcInspectionTool<UnusedArrayRule> {
@@ -48,7 +48,7 @@ public class UnusedArrayInspectionTool extends CodeNarcInspectionTool<UnusedArra
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unused/UnusedMethodParameterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unused/UnusedMethodParameterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unused.UnusedMethodParameterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnusedMethodParameterInspectionTool extends CodeNarcInspectionTool<UnusedMethodParameterRule> {
@@ -66,7 +66,7 @@ public class UnusedMethodParameterInspectionTool extends CodeNarcInspectionTool<
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unused/UnusedObjectInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unused/UnusedObjectInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unused.UnusedObjectRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnusedObjectInspectionTool extends CodeNarcInspectionTool<UnusedObjectRule> {
@@ -48,7 +48,7 @@ public class UnusedObjectInspectionTool extends CodeNarcInspectionTool<UnusedObj
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unused/UnusedPrivateFieldInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unused/UnusedPrivateFieldInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unused.UnusedPrivateFieldRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnusedPrivateFieldInspectionTool extends CodeNarcInspectionTool<UnusedPrivateFieldRule> {
@@ -75,7 +75,7 @@ public class UnusedPrivateFieldInspectionTool extends CodeNarcInspectionTool<Unu
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unused/UnusedPrivateMethodInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unused/UnusedPrivateMethodInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unused.UnusedPrivateMethodRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnusedPrivateMethodInspectionTool extends CodeNarcInspectionTool<UnusedPrivateMethodRule> {
@@ -57,7 +57,7 @@ public class UnusedPrivateMethodInspectionTool extends CodeNarcInspectionTool<Un
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unused/UnusedPrivateMethodParameterInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unused/UnusedPrivateMethodParameterInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unused.UnusedPrivateMethodParameterRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnusedPrivateMethodParameterInspectionTool extends CodeNarcInspectionTool<UnusedPrivateMethodParameterRule> {
@@ -57,7 +57,7 @@ public class UnusedPrivateMethodParameterInspectionTool extends CodeNarcInspecti
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/inspections/unused/UnusedVariableInspectionTool.java
+++ b/src/main/java/org/codenarc/idea/inspections/unused/UnusedVariableInspectionTool.java
@@ -8,7 +8,7 @@ import javax.annotation.Generated;
 import org.codenarc.idea.CodeNarcInspectionTool;
 import org.codenarc.rule.Violation;
 import org.codenarc.rule.unused.UnusedVariableRule;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 @Generated("You can customize this class at the end of the file or remove this annotation to skip regeneration completely")
 public class UnusedVariableInspectionTool extends CodeNarcInspectionTool<UnusedVariableRule> {
@@ -57,7 +57,7 @@ public class UnusedVariableInspectionTool extends CodeNarcInspectionTool<UnusedV
     // custom code can be written after this line and it will be preserved during the regeneration
 
     @Override
-    protected @NotNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
+    protected @NonNull Collection<LocalQuickFix> getQuickFixesFor(Violation violation, PsiElement violatingElement) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/codenarc/idea/quickfix/AddExplicitReturnQuickFix.java
+++ b/src/main/java/org/codenarc/idea/quickfix/AddExplicitReturnQuickFix.java
@@ -6,20 +6,24 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.IncorrectOperationException;
 import org.codenarc.idea.CodeNarcBundle;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.codeInspection.GroovyFix;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.GrStatement;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.blocks.GrCodeBlock;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Arrays;
 
+@NullMarked
 public class AddExplicitReturnQuickFix extends GroovyFix {
-
     @Override
-    protected void doFix(@NotNull Project project, @NotNull ProblemDescriptor problemDescriptor) throws IncorrectOperationException {
+    protected void doFix(Project project, ProblemDescriptor problemDescriptor) throws IncorrectOperationException {
         PsiElement psiElement = problemDescriptor.getPsiElement();
 
-        GrCodeBlock body = Arrays.stream(psiElement.getChildren()).filter(e -> e instanceof GrCodeBlock).findFirst().map(GrCodeBlock.class::cast).orElse(null);
+        GrCodeBlock body = Arrays.stream(psiElement.getChildren())
+            .filter(e -> e instanceof GrCodeBlock)
+            .findFirst()
+            .map(GrCodeBlock.class::cast)
+            .orElse(null);
 
         if (body == null) {
             return;
@@ -39,8 +43,7 @@ public class AddExplicitReturnQuickFix extends GroovyFix {
     }
 
     @Override
-    public @IntentionFamilyName @NotNull String getFamilyName() {
+    public @IntentionFamilyName String getFamilyName() {
         return CodeNarcBundle.message("add.explicit.return");
     }
-
 }

--- a/src/main/java/org/codenarc/idea/quickfix/ConvertGStringToStringReusableIntention.java
+++ b/src/main/java/org/codenarc/idea/quickfix/ConvertGStringToStringReusableIntention.java
@@ -4,30 +4,35 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.IncorrectOperationException;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.intentions.base.Intention;
 import org.jetbrains.plugins.groovy.intentions.base.PsiElementPredicate;
 import org.jetbrains.plugins.groovy.intentions.conversions.strings.ConvertGStringToStringIntention;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.literals.GrLiteral;
 import org.jetbrains.plugins.groovy.lang.psi.impl.PsiImplUtil;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public class ConvertGStringToStringReusableIntention extends Intention implements ReusableIntention {
-  private final ConvertGStringToStringIntention delegate = new ConvertGStringToStringIntention();
+    private final ConvertGStringToStringIntention delegate = new ConvertGStringToStringIntention();
 
-  @Override
-  public Class<?> getDelegateClass() {
-    return delegate.getClass();
-  }
+    @Override
+    public Class<?> getDelegateClass() {
+        return delegate.getClass();
+    }
 
-  @Override
-  public void processIntention(@NotNull PsiElement element, @NotNull Project project, Editor editor) throws IncorrectOperationException {
-    final GrLiteral exp = (GrLiteral)element;
-    PsiImplUtil.replaceExpression(ConvertGStringToStringIntention.convertGStringLiteralToStringLiteral(exp), exp);
-  }
+    @Override
+    public void processIntention(
+        PsiElement element,
+        Project project,
+        @Nullable Editor editor
+    ) throws IncorrectOperationException {
+        final GrLiteral exp = (GrLiteral) element;
+        PsiImplUtil.replaceExpression(ConvertGStringToStringIntention.convertGStringLiteralToStringLiteral(exp), exp);
+    }
 
-  @NotNull
-  @Override
-  public PsiElementPredicate getElementPredicate() {
-    return delegate.getElementPredicate();
-  }
+    @Override
+    public PsiElementPredicate getElementPredicate() {
+        return delegate.getElementPredicate();
+    }
 }

--- a/src/main/java/org/codenarc/idea/quickfix/DeleteElementQuickFix.java
+++ b/src/main/java/org/codenarc/idea/quickfix/DeleteElementQuickFix.java
@@ -7,25 +7,26 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.IncorrectOperationException;
 import com.siyeh.ig.psiutils.CommentTracker;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.codeInspection.GroovyFix;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class DeleteElementQuickFix extends GroovyFix {
     private final DeleteElementFix delegate;
     private final PsiElement element;
 
-    public DeleteElementQuickFix(@NotNull PsiElement element) {
+    public DeleteElementQuickFix(PsiElement element) {
         this.element = element;
         delegate = new DeleteElementFix(element);
     }
 
     @Override
-    protected void doFix(@NotNull Project project, @NotNull ProblemDescriptor problemDescriptor) throws IncorrectOperationException {
-        (new CommentTracker()).deleteAndRestoreComments(element);
+    protected void doFix(Project project, ProblemDescriptor problemDescriptor) throws IncorrectOperationException {
+        new CommentTracker().deleteAndRestoreComments(element);
     }
 
     @Override
-    public @IntentionFamilyName @NotNull String getFamilyName() {
+    public @IntentionFamilyName String getFamilyName() {
         return delegate.getFamilyName();
     }
 }

--- a/src/main/java/org/codenarc/idea/quickfix/IntentionQuickFix.java
+++ b/src/main/java/org/codenarc/idea/quickfix/IntentionQuickFix.java
@@ -8,13 +8,13 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiEditorUtil;
 import com.intellij.util.IncorrectOperationException;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.codeInspection.GroovyFix;
 import org.jetbrains.plugins.groovy.intentions.GroovyIntentionsBundle;
 import org.jetbrains.plugins.groovy.intentions.base.PsiElementPredicate;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class IntentionQuickFix extends GroovyFix {
-
   public static LocalQuickFix from(ReusableIntention action) {
     return new IntentionQuickFix(action);
   }
@@ -26,19 +26,18 @@ public class IntentionQuickFix extends GroovyFix {
   }
 
   @Override
-  @NotNull
+  @NonNull
   public String getFamilyName() {
-    //return GroovyIntentionsBundle.message(getPrefix(intention.getClass().getSuperclass()) + ".family.name");
     return GroovyIntentionsBundle.message(getPrefix(intention.getDelegateClass()) + ".family.name");
   }
 
   @Override
-  protected void doFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) throws IncorrectOperationException {
+  protected void doFix(@NonNull Project project, @NonNull ProblemDescriptor descriptor) throws IncorrectOperationException {
     Editor editor = PsiEditorUtil.findEditor(descriptor.getPsiElement());
     callOnProblemDescriptor(descriptor.getPsiElement(), project, editor);
   }
 
-  private static PsiElement findMatchingElement(PsiElement violatingElement, PsiElementPredicate predicate) {
+  private static @Nullable PsiElement findMatchingElement(PsiElement violatingElement, PsiElementPredicate predicate) {
     if (predicate.satisfiedBy(violatingElement)) {
       return violatingElement;
     }
@@ -51,10 +50,10 @@ public class IntentionQuickFix extends GroovyFix {
     return null;
   }
 
-  private void callOnProblemDescriptor(@NotNull PsiElement element, @NotNull Project project, Editor editor) {
-    if (element instanceof PsiFile) {
+  private void callOnProblemDescriptor(@NonNull PsiElement element, @NonNull Project project, Editor editor) {
+    if (element instanceof PsiFile el) {
       // single call
-      intention.invoke(project, editor, (PsiFile) element);
+      intention.invoke(project, editor, el);
       return;
     }
 
@@ -64,7 +63,7 @@ public class IntentionQuickFix extends GroovyFix {
       return;
     }
 
-    // requires reflective call to processIntention otherwise Fix All does not work
+    // requires a reflective call to processIntention otherwise Fix All does not work
     PsiElementPredicate predicate = intention.getElementPredicate();
     PsiElement found = findMatchingElement(element, predicate);
 
@@ -93,5 +92,4 @@ public class IntentionQuickFix extends GroovyFix {
     }
     return buffer.toString();
   }
-
 }

--- a/src/main/java/org/codenarc/idea/quickfix/RemoveRedundantClassPropertyReusableIntention.java
+++ b/src/main/java/org/codenarc/idea/quickfix/RemoveRedundantClassPropertyReusableIntention.java
@@ -5,13 +5,14 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.IncorrectOperationException;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.intentions.base.Intention;
 import org.jetbrains.plugins.groovy.intentions.base.PsiElementPredicate;
 import org.jetbrains.plugins.groovy.intentions.style.RemoveRedundantClassPropertyIntention;
-import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrExpression;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrReferenceExpression;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public class RemoveRedundantClassPropertyReusableIntention extends Intention implements ReusableIntention {
     private final RemoveRedundantClassPropertyIntention delegate = new RemoveRedundantClassPropertyIntention();
 
@@ -21,33 +22,29 @@ public class RemoveRedundantClassPropertyReusableIntention extends Intention imp
     }
 
     @Override
-    public void processIntention(@NotNull PsiElement element, @NotNull Project project, Editor editor) throws IncorrectOperationException {
+    public void processIntention(PsiElement element, Project project, @Nullable Editor editor) throws IncorrectOperationException {
         if (element instanceof GrReferenceExpression ref) {
-            ref.replaceWithExpression((GrExpression)ref.getQualifier(), true);
+            if (ref.getQualifier() != null) {
+                ref.replaceWithExpression(ref.getQualifier(), true);
+            }
         }
     }
 
-    @NotNull
     @Override
     public PsiElementPredicate getElementPredicate() {
-        return (element) -> {
-            boolean var10000;
+        return element -> {
             if (element instanceof GrReferenceExpression ref) {
                 if ("class".equals(ref.getReferenceName())) {
-                    PsiElement patt1231$temp = ref.getQualifier();
-                    if (patt1231$temp instanceof GrReferenceExpression) {
-                        GrReferenceExpression qualifier = (GrReferenceExpression)patt1231$temp;
-                        if (qualifier.resolve() instanceof PsiClass) {
-                            var10000 = true;
-                            return var10000;
+                    PsiElement qualifier = ref.getQualifier();
+                    if (qualifier instanceof GrReferenceExpression _qualifier) {
+                        if (_qualifier.resolve() instanceof PsiClass) {
+                            return true;
                         }
                     }
                 }
             }
 
-            var10000 = false;
-            return var10000;
+            return false;
         };
     }
-
 }

--- a/src/main/java/org/codenarc/idea/quickfix/ReplaceOnDemandImportFix.java
+++ b/src/main/java/org/codenarc/idea/quickfix/ReplaceOnDemandImportFix.java
@@ -22,7 +22,6 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.ClassUtil;
 import com.intellij.util.IncorrectOperationException;
 import com.siyeh.IntentionPowerPackBundle;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.codeInspection.GroovyFix;
 import org.jetbrains.plugins.groovy.lang.psi.GroovyFile;
 import org.jetbrains.plugins.groovy.lang.psi.GroovyPsiElement;
@@ -31,56 +30,59 @@ import org.jetbrains.plugins.groovy.lang.psi.GroovyRecursiveElementVisitor;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.typedef.GrTypeDefinition;
 import org.jetbrains.plugins.groovy.lang.psi.api.toplevel.imports.GrImportStatement;
 import org.jetbrains.plugins.groovy.lang.psi.api.types.GrCodeReferenceElement;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Function;
 
+@NullMarked
 public class ReplaceOnDemandImportFix extends GroovyFix {
-
     @Override
-    protected void doFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) throws IncorrectOperationException {
+    protected void doFix(Project project, ProblemDescriptor descriptor) throws IncorrectOperationException {
         if (descriptor.getPsiElement() instanceof GrImportStatement) {
             fixImport(project, (GrImportStatement) descriptor.getPsiElement());
         }
     }
 
     @Override
-    public @NotNull String getFamilyName() {
+    public String getFamilyName() {
         return IntentionPowerPackBundle.message("replace.on.demand.import.intention.family.name");
     }
 
-    protected void fixImport(@NotNull Project project, @NotNull GrImportStatement importStatement) {
+    protected void fixImport(Project project, GrImportStatement importStatement) {
         final GroovyFile groovyFile = (GroovyFile) importStatement.getContainingFile();
         final GroovyPsiElementFactory factory = GroovyPsiElementFactory.getInstance(project);
 
         if (!importStatement.isStatic()) {
             final GrTypeDefinition[] classes = (GrTypeDefinition[]) groovyFile.getClasses();
             final String qualifiedName = importStatement.getImportFqn();
+            if (qualifiedName == null) {
+                return;
+            }
+
             final ClassCollector visitor = new ClassCollector(qualifiedName);
             for (GrTypeDefinition aClass : classes) {
                 aClass.accept(visitor);
             }
             final PsiClass[] importedClasses = visitor.getImportedClasses();
             Arrays.sort(importedClasses, new PsiClassComparator());
-            createImportStatements(
-                importStatement,
-                importedClasses,
-                clazz -> factory.createImportStatement(clazz.getQualifiedName(), false, false, null, null)
-            );
+            createImportStatements(importStatement, importedClasses, factory);
         }
     }
 
-    private static <T> void createImportStatements(
+    private static void createImportStatements(
         GrImportStatement importStatement,
-        T[] importedMembers,
-        Function<? super T, ? extends GrImportStatement> function
+        PsiClass[] importedMembers,
+        GroovyPsiElementFactory factory
     ) {
         final GroovyFile groovyFile = (GroovyFile) importStatement.getParent();
-        for (T importedMember : importedMembers) {
-            groovyFile.addImport(function.apply(importedMember));
+        for (PsiClass importedMember : importedMembers) {
+            var qualifiedName = importedMember.getQualifiedName();
+            if (qualifiedName != null) {
+                groovyFile.addImport(factory.createImportStatement(qualifiedName, false, false, null, null));
+            }
         }
         PsiElement maybeNewLine = importStatement.getPrevSibling();
         if (maybeNewLine != null && maybeNewLine.toString().contains("new line")) {
@@ -99,18 +101,16 @@ public class ReplaceOnDemandImportFix extends GroovyFix {
         }
 
         @Override
-        public void visitElement(@NotNull GroovyPsiElement element) {
+        public void visitElement(GroovyPsiElement element) {
             super.visitElement(element);
-            if (element instanceof GrCodeReferenceElement) {
-                GrCodeReferenceElement ref = (GrCodeReferenceElement) element;
+            if (element instanceof GrCodeReferenceElement ref) {
                 if (ref.isQualified()) {
                     return;
                 }
                 final PsiElement resolvedElement = ref.resolve();
-                if (!(resolvedElement instanceof PsiClass)) {
+                if (!(resolvedElement instanceof PsiClass aClass)) {
                     return;
                 }
-                final PsiClass aClass = (PsiClass) resolvedElement;
                 final String qualifiedName = aClass.getQualifiedName();
                 final String packageName =
                     ClassUtil.extractPackageName(qualifiedName);
@@ -121,7 +121,7 @@ public class ReplaceOnDemandImportFix extends GroovyFix {
             }
         }
 
-        public PsiClass[] getImportedClasses() {
+        private PsiClass[] getImportedClasses() {
             return importedClasses.toArray(PsiClass.EMPTY_ARRAY);
         }
     }
@@ -136,6 +136,11 @@ public class ReplaceOnDemandImportFix extends GroovyFix {
             if (qualifiedName1 == null) {
                 return -1;
             }
+
+            if (qualifiedName2 == null) {
+                return 1;
+            }
+
             return qualifiedName1.compareTo(qualifiedName2);
         }
     }

--- a/src/main/java/org/codenarc/idea/quickfix/ReplacePrintlnWithAnnotationFix.java
+++ b/src/main/java/org/codenarc/idea/quickfix/ReplacePrintlnWithAnnotationFix.java
@@ -1,34 +1,40 @@
 package org.codenarc.idea.quickfix;
 
-import com.intellij.codeInsight.intention.AddAnnotationPsiFix;
 import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiNameValuePair;
+import com.intellij.psi.codeStyle.JavaCodeStyleManager;
 import com.intellij.psi.util.PsiUtil;
 import com.intellij.util.IncorrectOperationException;
 import groovy.util.logging.Slf4j;
 import org.codenarc.idea.CodeNarcBundle;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.codeInspection.GroovyFix;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrMethodCall;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class ReplacePrintlnWithAnnotationFix extends GroovyFix {
-
     @Override
-    protected void doFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) throws IncorrectOperationException {
+    protected void doFix(Project project, ProblemDescriptor descriptor) throws IncorrectOperationException {
         PsiClass topLevelClass = PsiUtil.getTopLevelClass(descriptor.getPsiElement());
 
         if (topLevelClass == null) {
             return;
         }
 
-        new AddAnnotationPsiFix(Slf4j.class.getName(), topLevelClass, new PsiNameValuePair[0]).applyFix();
+        var annotationFqn = Slf4j.class.getName();
+        var modifierList = topLevelClass.getModifierList();
+        if (modifierList != null && modifierList.findAnnotation(annotationFqn) == null) {
+            PsiAnnotation annotation = modifierList.addAnnotation(annotationFqn);
+            JavaCodeStyleManager.getInstance(project).shortenClassReferences(annotation);
+        }
+
         new ReplaceStatementFix(GrMethodCall.class, "println", "log.info").applyFix(project, descriptor);
     }
 
     @Override
-    public @NotNull String getFamilyName() {
+    public String getFamilyName() {
         return CodeNarcBundle.message("use.logging.instead.of.println");
     }
 }

--- a/src/main/java/org/codenarc/idea/quickfix/ReplaceStatementFix.java
+++ b/src/main/java/org/codenarc/idea/quickfix/ReplaceStatementFix.java
@@ -5,10 +5,11 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.IncorrectOperationException;
 import org.codenarc.idea.CodeNarcBundle;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.codeInspection.GroovyFix;
 import org.jetbrains.plugins.groovy.lang.psi.api.statements.GrStatement;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class ReplaceStatementFix extends GroovyFix {
     private final Class<? extends GrStatement> target;
     private final String original;
@@ -21,16 +22,16 @@ public class ReplaceStatementFix extends GroovyFix {
     }
 
     @Override
-    public @NotNull String getFamilyName() {
+    public String getFamilyName() {
         return CodeNarcBundle.message("replace.text", original, replacement);
     }
 
     @Override
-    protected void doFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) throws IncorrectOperationException {
+    protected void doFix(Project project, ProblemDescriptor descriptor) throws IncorrectOperationException {
         replaceCode(descriptor.getPsiElement());
     }
 
-    private boolean replaceCode(@NotNull PsiElement element) {
+    private boolean replaceCode(PsiElement element) {
         if (target.isInstance(element)) {
             replaceCode((GrStatement) element, element.getText());
             return true;
@@ -45,7 +46,7 @@ public class ReplaceStatementFix extends GroovyFix {
         return false;
     }
 
-    private void replaceCode(@NotNull GrStatement statement, String text) {
+    private void replaceCode(GrStatement statement, String text) {
         replaceStatement(statement, text.replace(original, replacement));
     }
 }

--- a/src/main/java/org/codenarc/idea/quickfix/ReusableIntention.java
+++ b/src/main/java/org/codenarc/idea/quickfix/ReusableIntention.java
@@ -5,18 +5,23 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.IncorrectOperationException;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.groovy.intentions.base.PsiElementPredicate;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
- * Exposes internal protected methods of {@link org.jetbrains.plugins.groovy.intentions.base.Intention} to allow using it as quick fix.
+ * Exposes internal protected methods of {@link org.jetbrains.plugins.groovy.intentions.base.Intention} to allow using
+ * it as quick fix.
  */
+@NullMarked
 public interface ReusableIntention extends IntentionAction {
   Class<?> getDelegateClass();
 
-  void processIntention(@NotNull PsiElement element, @NotNull Project project, Editor editor) throws IncorrectOperationException;
+  void processIntention(
+      PsiElement element,
+      Project project,
+      @Nullable Editor editor
+  ) throws IncorrectOperationException;
 
-  @NotNull
   PsiElementPredicate getElementPredicate();
-
 }

--- a/src/main/java/org/codenarc/idea/ui/Helpers.java
+++ b/src/main/java/org/codenarc/idea/ui/Helpers.java
@@ -6,6 +6,8 @@ import groovy.lang.MetaClass;
 import groovy.lang.MetaProperty;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codenarc.idea.CodeNarcInspectionTool;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import javax.swing.JPanel;
 import java.awt.GridBagConstraints;
@@ -14,18 +16,19 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@NullMarked
 public class Helpers {
+    private static final List<String> EXCLUDED_STATIC_FIELDS = List.of(
+        "name", "description", "priority", "astVisitor", "astVisitorClass", "violationMessage", "compilerPhase",
+        "class", "enabled"
+    );
 
-    private static final List<String> EXCLUDED_STATIC_FIELDS = Arrays.asList("name", "description", "priority", "astVisitor", "astVisitorClass", "violationMessage", "compilerPhase", "class", "enabled");
     private static final List<String> EXCLUDED_FROM_AUTO_PROXYING_FIELD_NAMES = Stream.of(
             EXCLUDED_STATIC_FIELDS,
-            Arrays.asList("applyToFilesMatching", "doNotApplyToFilesMatching", "applyToFileNames", "doNotApplyToFileNames")
-    ).flatMap(Collection::stream).collect(Collectors.toList());
+            List.of("applyToFilesMatching", "doNotApplyToFilesMatching", "applyToFileNames", "doNotApplyToFileNames")
+    ).flatMap(List::stream).toList();
 
-
-    public static JPanel createOptionsPanel(final CodeNarcInspectionTool<?> instance) {
-        Objects.requireNonNull(instance);
-
+    public static @Nullable JPanel createOptionsPanel(final CodeNarcInspectionTool<?> instance) {
         MetaClass ruleMetaClass = DefaultGroovyMethods.getMetaClass(instance.getRule());
 
         if (ruleMetaClass.getProperties().isEmpty()) {
@@ -64,15 +67,18 @@ public class Helpers {
                 panel.add(subPanel, constraints);
                 constraints.gridy = row++;
             }
-
         }
-
 
         HyperlinkLabel linkLabel = new HyperlinkLabel();
 
-        String fragment = instance.getRule().getClass().getSimpleName().toLowerCase().replace("rule", "-rule");
+        String fragment = instance.getRule().getClass().getSimpleName()
+            .toLowerCase(Locale.ROOT)
+            .replace("rule", "-rule");
 
-        linkLabel.setHyperlinkTarget("https://codenarc.org/codenarc-rules-" + instance.getRuleset().toLowerCase() + ".html#" + fragment);
+        linkLabel.setHyperlinkTarget(
+            "https://codenarc.org/codenarc-rules-" + instance.getRuleset().toLowerCase(Locale.ROOT) + ".html#" +
+                fragment
+        );
         linkLabel.setHyperlinkText("An explanation of the rule at the CodeNarc website");
 
         panel.add(linkLabel, constraints);
@@ -81,19 +87,22 @@ public class Helpers {
             return panel;
         }
 
-
         return null;
     }
 
     public static String camelCaseToSentence(String camelCased) {
-        StringBuilder buf = new StringBuilder(camelCased);
-        if (buf.length() == 0) {
+        if (camelCased.isBlank()) {
             return camelCased;
         }
 
+        StringBuilder buf = new StringBuilder(camelCased);
         buf.setCharAt(0, Character.toUpperCase(buf.charAt(0)));
         for (int i = 1; i < buf.length() - 1; i++) {
-            if (Character.isLowerCase(buf.charAt(i - 1)) && Character.isUpperCase(buf.charAt(i)) && Character.isLowerCase(buf.charAt(i + 1))) {
+            if (
+                Character.isLowerCase(buf.charAt(i - 1)) &&
+                Character.isUpperCase(buf.charAt(i)) &&
+                Character.isLowerCase(buf.charAt(i + 1))
+            ) {
                 buf.insert(i++, " ");
                 buf.setCharAt(i, Character.toLowerCase(buf.charAt(i)));
             }
@@ -102,29 +111,26 @@ public class Helpers {
         return buf.toString();
     }
 
-    @SuppressWarnings("CodeNarc.Instanceof")
     public static List<MetaProperty> proxyableProps(Class<?> clazz) {
         return DefaultGroovyMethods.getMetaClass(clazz).getProperties().stream()
-                .filter(p -> {
-                    if (!(p instanceof MetaBeanProperty)) {
-                        return false;
-                    }
-                    MetaBeanProperty prop = (MetaBeanProperty) p;
-                    return !EXCLUDED_FROM_AUTO_PROXYING_FIELD_NAMES.contains(prop.getName()) && prop.getSetter() != null && prop.getGetter() != null;
-                })
+                .filter(p ->
+                    p instanceof MetaBeanProperty _p &&
+                    !EXCLUDED_FROM_AUTO_PROXYING_FIELD_NAMES.contains(_p.getName()) &&
+                    _p.getSetter() != null &&
+                    _p.getGetter() != null
+                )
                 .sorted(Comparator.comparing(MetaProperty::getName))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public static List<MetaProperty> optionableProps(Class<?> clazz) {
         return DefaultGroovyMethods.getMetaClass(clazz).getProperties().stream()
-                .filter(p -> {
-                    if (!(p instanceof MetaBeanProperty)) {
-                        return false;
-                    }
-                    MetaBeanProperty prop = (MetaBeanProperty) p;
-                    return !EXCLUDED_STATIC_FIELDS.contains(prop.getName()) && prop.getSetter() != null && prop.getGetter() != null;
-                })
+                .filter(p ->
+                    p instanceof MetaBeanProperty _p &&
+                    !EXCLUDED_STATIC_FIELDS.contains(_p.getName()) &&
+                    _p.getSetter() != null &&
+                    _p.getGetter() != null
+                )
                 .sorted(Comparator.comparing(MetaProperty::getName))
                 .collect(Collectors.toList());
     }
@@ -133,5 +139,4 @@ public class Helpers {
         ClassLoader classLoader = CodeNarcInspectionTool.class.getClassLoader();
         return Class.forName(ruleClass, true, classLoader);
     }
-
 }

--- a/src/main/java/org/codenarc/idea/ui/SingleCheckboxOptionsPanel.java
+++ b/src/main/java/org/codenarc/idea/ui/SingleCheckboxOptionsPanel.java
@@ -3,16 +3,16 @@ package org.codenarc.idea.ui;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codenarc.rule.Rule;
 import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.*;
 
+@NullMarked
 public class SingleCheckboxOptionsPanel extends JPanel {
-
-    public SingleCheckboxOptionsPanel(@NotNull String label, @NotNull Rule owner, @NonNls String property) {
+    public SingleCheckboxOptionsPanel(String label, Rule owner, @NonNls String property) {
         super(new GridBagLayout());
         final Boolean selected = (Boolean) DefaultGroovyMethods.getMetaClass(owner).getProperty(owner, property);
         final JCheckBox checkBox = new JCheckBox(label, selected != null && selected);
@@ -32,18 +32,11 @@ public class SingleCheckboxOptionsPanel extends JPanel {
         add(checkBox, constraints);
     }
 
-    private static class SingleCheckboxChangeListener implements ChangeListener {
-
-        private final Rule owner;
-        private final String property;
-        private final ButtonModel model;
-
-        public SingleCheckboxChangeListener(Rule owner, String property, ButtonModel model) {
-            this.owner = owner;
-            this.property = property;
-            this.model = model;
-        }
-
+    private record SingleCheckboxChangeListener(
+        Rule owner,
+        String property,
+        ButtonModel model
+    ) implements ChangeListener {
         @Override
         public void stateChanged(ChangeEvent e) {
             DefaultGroovyMethods.getMetaClass(owner).setProperty(owner, property, model.isSelected());

--- a/src/main/java/org/codenarc/idea/ui/SingleIntegerFieldOptionsPanel.java
+++ b/src/main/java/org/codenarc/idea/ui/SingleIntegerFieldOptionsPanel.java
@@ -5,7 +5,7 @@ import com.intellij.util.ui.UIUtil;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codenarc.rule.Rule;
 import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
@@ -24,7 +24,12 @@ public class SingleIntegerFieldOptionsPanel extends JPanel {
         this(labelString, owner, property, 6);
     }
 
-    public SingleIntegerFieldOptionsPanel(String labelString, final Rule owner, @NonNls final String property, int integerFieldColumns) {
+    public SingleIntegerFieldOptionsPanel(
+        String labelString,
+        final Rule owner,
+        @NonNls final String property,
+        int integerFieldColumns
+    ) {
         super(new GridBagLayout());
         final JLabel label = new JLabel(labelString);
         final JFormattedTextField valueField = createIntegerFieldTrackingValue(owner, property, integerFieldColumns);
@@ -46,7 +51,11 @@ public class SingleIntegerFieldOptionsPanel extends JPanel {
         add(valueField, constraints);
     }
 
-    public static JFormattedTextField createIntegerFieldTrackingValue(@NotNull Rule owner, @NotNull String property, int integerFieldColumns) {
+    public static JFormattedTextField createIntegerFieldTrackingValue(
+        @NonNull Rule owner,
+        @NonNull String property,
+        int integerFieldColumns
+    ) {
         JFormattedTextField valueField = new JFormattedTextField();
         valueField.setEnabled(true);
         valueField.setColumns(integerFieldColumns);
@@ -55,15 +64,19 @@ public class SingleIntegerFieldOptionsPanel extends JPanel {
     }
 
     /**
-     * Sets integer number format to JFormattedTextField instance,
-     * sets value of JFormattedTextField instance to object's field value,
-     * synchronizes object's field value with the value of JFormattedTextField instance.
+     * Sets an integer number format to JFormattedTextField instance,
+     * sets the value of JFormattedTextField instance to the object's field value,
+     * synchronizes the object's field value with the value of JFormattedTextField instance.
      *
      * @param textField JFormattedTextField instance
      * @param owner     an object whose field is synchronized with {@code textField}
      * @param property  object's field name for synchronization
      */
-    public static void setupIntegerFieldTrackingValue(final JFormattedTextField textField, final Rule owner, final String property) {
+    public static void setupIntegerFieldTrackingValue(
+        final JFormattedTextField textField,
+        final Rule owner,
+        final String property
+    ) {
         NumberFormat formatter = NumberFormat.getIntegerInstance();
         formatter.setParseIntegerOnly(true);
         textField.setFormatterFactory(new DefaultFormatterFactory(new NumberFormatter(formatter)));
@@ -71,13 +84,17 @@ public class SingleIntegerFieldOptionsPanel extends JPanel {
         final Document document = textField.getDocument();
         document.addDocumentListener(new DocumentAdapter() {
             @Override
-            public void textChanged(@NotNull DocumentEvent e) {
+            public void textChanged(@NonNull DocumentEvent e) {
                 try {
                     textField.commitEdit();
                 } catch (ParseException ex) {
                     throw new IllegalArgumentException(ex);
                 }
-                DefaultGroovyMethods.getMetaClass(owner).setProperty(owner, property, ((Number) textField.getValue()).intValue());
+                DefaultGroovyMethods.getMetaClass(owner).setProperty(
+                    owner,
+                    property,
+                    ((Number) textField.getValue()).intValue()
+                );
             }
 
         });

--- a/src/main/java/org/codenarc/idea/ui/SingleTextFieldOptionsPanel.java
+++ b/src/main/java/org/codenarc/idea/ui/SingleTextFieldOptionsPanel.java
@@ -5,7 +5,7 @@ import com.intellij.util.ui.UIUtil;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codenarc.rule.Rule;
 import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -18,7 +18,12 @@ public class SingleTextFieldOptionsPanel extends JPanel {
         this(labelString, owner, property, 32);
     }
 
-    public SingleTextFieldOptionsPanel(String labelString, final Rule owner, @NonNls final String property, int textFieldColumns) {
+    public SingleTextFieldOptionsPanel(
+        String labelString,
+        final Rule owner,
+        @NonNls final String property,
+        int textFieldColumns
+    ) {
         super(new GridBagLayout());
         final JLabel label = new JLabel(labelString);
         final JFormattedTextField valueField = createIntegerFieldTrackingValue(owner, property, textFieldColumns);
@@ -40,7 +45,11 @@ public class SingleTextFieldOptionsPanel extends JPanel {
         add(valueField, constraints);
     }
 
-    private static JFormattedTextField createIntegerFieldTrackingValue(@NotNull Rule owner, @NotNull String property, int textFieldColumns) {
+    private static JFormattedTextField createIntegerFieldTrackingValue(
+        @NonNull Rule owner,
+        @NonNull String property,
+        int textFieldColumns
+    ) {
         JFormattedTextField valueField = new JFormattedTextField();
         valueField.setEnabled(true);
         valueField.setColumns(textFieldColumns);
@@ -49,20 +58,24 @@ public class SingleTextFieldOptionsPanel extends JPanel {
     }
 
     /**
-     * Sets integer number format to JFormattedTextField instance,
-     * sets value of JFormattedTextField instance to object's field value,
-     * synchronizes object's field value with the value of JFormattedTextField instance.
+     * Sets an integer number format to JFormattedTextField instance,
+     * sets the value of JFormattedTextField instance to the object's field value,
+     * synchronizes the object's field value with the value of JFormattedTextField instance.
      *
      * @param textField JFormattedTextField instance
      * @param owner     an object whose field is synchronized with {@code textField}
      * @param property  object's field name for synchronization
      */
-    private static void setupIntegerFieldTrackingValue(final JFormattedTextField textField, final Rule owner, final String property) {
+    private static void setupIntegerFieldTrackingValue(
+        final JFormattedTextField textField,
+        final Rule owner,
+        final String property
+    ) {
         textField.setValue(DefaultGroovyMethods.getMetaClass(owner).getProperty(owner, property));
         final Document document = textField.getDocument();
         document.addDocumentListener(new DocumentAdapter() {
             @Override
-            public void textChanged(@NotNull DocumentEvent e) {
+            public void textChanged(@NonNull DocumentEvent e) {
                 try {
                     textField.commitEdit();
                 } catch (ParseException ex) {

--- a/src/test/groovy/org/codenarc/idea/testing/CompoundTestLibrary.java
+++ b/src/test/groovy/org/codenarc/idea/testing/CompoundTestLibrary.java
@@ -2,10 +2,10 @@ package org.codenarc.idea.testing;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ModifiableRootModel;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public final class CompoundTestLibrary implements TestLibrary {
-
     private final TestLibrary[] myLibraries;
 
     public CompoundTestLibrary(TestLibrary... libraries) {
@@ -14,10 +14,9 @@ public final class CompoundTestLibrary implements TestLibrary {
     }
 
     @Override
-    public void addTo(@NotNull Module module, @NotNull ModifiableRootModel model) {
+    public void addTo(Module module, ModifiableRootModel model) {
         for (TestLibrary library : myLibraries) {
             library.addTo(module, model);
         }
     }
-
 }

--- a/src/test/groovy/org/codenarc/idea/testing/FixtureHelper.groovy
+++ b/src/test/groovy/org/codenarc/idea/testing/FixtureHelper.groovy
@@ -11,16 +11,16 @@ import groovy.transform.CompileStatic
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.jetbrains.annotations.NonNls
-import org.jetbrains.annotations.NotNull
-import org.jetbrains.annotations.Nullable
+import org.jspecify.annotations.NullMarked
+import org.jspecify.annotations.Nullable
 import org.junit.Ignore
 
 /**
  * @author peter
  */
 @Ignore // not a JUnit test
+@NullMarked
 class FixtureHelper extends LightJavaCodeInsightFixtureTestCase implements Closeable {
-
     static FixtureHelper groovy40() {
         return new FixtureHelper(GroovyProjectDescriptors.GROOVY_4_0, null)
     }
@@ -46,16 +46,15 @@ class FixtureHelper extends LightJavaCodeInsightFixtureTestCase implements Close
     }
 
     FixtureHelper start(
-            @DelegatesTo(value = JavaCodeInsightTestFixture, strategy = Closure.DELEGATE_FIRST)
-                    @ClosureParams(value = SimpleType, options = 'com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture')
-            Closure<?> fixtureConfig
+        @DelegatesTo(value = JavaCodeInsightTestFixture, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType, options = 'com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture')
+        Closure<?> fixtureConfig
     ) {
         setUp()
         fixture.with fixtureConfig
         this
     }
 
-    @NotNull
     JavaCodeInsightTestFixture getFixture() {
         myFixture
     }
@@ -73,7 +72,6 @@ class FixtureHelper extends LightJavaCodeInsightFixtureTestCase implements Close
     }
 
     @Override
-    @NotNull
     protected LightProjectDescriptor getProjectDescriptor() {
         return projectDescriptor
     }

--- a/src/test/groovy/org/codenarc/idea/testing/InspectionSpec.groovy
+++ b/src/test/groovy/org/codenarc/idea/testing/InspectionSpec.groovy
@@ -14,7 +14,7 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture
 import groovy.transform.CompileDynamic
-import org.jetbrains.annotations.NotNull
+import org.jspecify.annotations.NonNull
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -201,7 +201,7 @@ abstract class InspectionSpec extends Specification {
     }
 
     @SuppressWarnings('TrailingWhitespace')
-    @NotNull
+    @NonNull
     protected String readBeforeFile(JavaCodeInsightTestFixture fixture) {
         String before = fixt.readText('before.txt')
 

--- a/src/test/groovy/org/codenarc/idea/testing/LibraryLightProjectDescriptor.java
+++ b/src/test/groovy/org/codenarc/idea/testing/LibraryLightProjectDescriptor.java
@@ -4,10 +4,10 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class LibraryLightProjectDescriptor extends DefaultLightProjectDescriptor {
-
     private final TestLibrary myLibrary;
 
     public LibraryLightProjectDescriptor(TestLibrary library) {
@@ -15,9 +15,8 @@ public class LibraryLightProjectDescriptor extends DefaultLightProjectDescriptor
     }
 
     @Override
-    public void configureModule(@NotNull Module module, @NotNull ModifiableRootModel model, @NotNull ContentEntry contentEntry) {
+    public void configureModule( Module module, ModifiableRootModel model, ContentEntry contentEntry) {
         super.configureModule(module, model, contentEntry);
         myLibrary.addTo(module, model);
     }
-
 }

--- a/src/test/groovy/org/codenarc/idea/testing/RepositoryTestLibrary.java
+++ b/src/test/groovy/org/codenarc/idea/testing/RepositoryTestLibrary.java
@@ -10,13 +10,15 @@ import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.roots.libraries.ui.OrderRoot;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.utils.library.RepositoryLibraryProperties;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
+@NullMarked
 public final class RepositoryTestLibrary implements TestLibrary {
     public RepositoryTestLibrary(String... coordinates) {
         this(DependencyScope.COMPILE, coordinates);
@@ -35,7 +37,7 @@ public final class RepositoryTestLibrary implements TestLibrary {
     }
 
     @Override
-    public void addTo(@NotNull Module module, @NotNull ModifiableRootModel model) {
+    public void addTo(Module module, ModifiableRootModel model) {
         final LibraryTable.ModifiableModel tableModel = model.getModuleLibraryTable().getModifiableModel();
         Library library = tableModel.createLibrary(myCoordinates[0]);
         final Library.ModifiableModel libraryModel = library.getModifiableModel();
@@ -53,7 +55,7 @@ public final class RepositoryTestLibrary implements TestLibrary {
                 tableModel.commit();
         });
 
-        model.findLibraryOrderEntry(library).setScope(myDependencyScope);
+        Objects.requireNonNull(model.findLibraryOrderEntry(library)).setScope(myDependencyScope);
     }
 
     public static Collection<OrderRoot> loadRoots(Project project, String coordinates) {

--- a/src/test/groovy/org/codenarc/idea/testing/TestLibrary.java
+++ b/src/test/groovy/org/codenarc/idea/testing/TestLibrary.java
@@ -3,18 +3,17 @@ package org.codenarc.idea.testing;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public interface TestLibrary {
-
-  default void addTo(@NotNull Module module) {
+  default void addTo(Module module) {
     ModuleRootModificationUtil.updateModel(module, model -> addTo(module, model));
   }
 
-  void addTo(@NotNull Module module, @NotNull ModifiableRootModel model);
+  void addTo(Module module, ModifiableRootModel model);
 
-  @NotNull
-  default TestLibrary plus(@NotNull TestLibrary library) {
+  default TestLibrary plus(TestLibrary library) {
     return new CompoundTestLibrary(this, library);
   }
 }


### PR DESCRIPTION
Motivation: https://blog.jetbrains.com/idea/2025/11/one-could-simply-add-nullability-check-support-without-even-noticing-it/

Changes:
1. Bumped the plugin version to 7.0.7
2. Added [error-prone](https://github.com/google/error-prone) v2.45.0
3. Added [NullAway](https://github.com/uber/NullAway) v0.12.14
4. Added [JSpecify](https://github.com/jspecify/jspecify) v1.0.0
5. Replaced old JetBrains null-related annotations with JSpecify
6. Refactored all parts of the plugin to fix errors and warnings detected by `error-prone` and `NullAway`
7. Refactored `ReplacePrintlnWithAnnotationFix` to remove one deprecated class
